### PR TITLE
Refactor paper retrieval to RSS, switch LLM to Gemini, fix paper linking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# ArXivSum Development Guide
+
+## Commands
+- Run application: `PYTHONPATH=. .venv/bin/python -m api.main`
+- Run tests: `PYTHONPATH=. .venv/bin/python -m pytest api/tests/test_main.py`
+- Run specific test: `PYTHONPATH=. .venv/bin/python -m pytest api/tests/test_main.py::test_function_name`
+- Start dev server: `docker compose up --build`
+- Start prod server: `docker-compose -f docker-compose.prod.yml up -d`
+
+## Code Style Guide
+- **Imports**: Group imports (stdlib → third-party → local)
+- **Formatting**: 4-space indentation, 120 char line limit
+- **Types**: Use docstrings for type documentation
+- **Naming**: snake_case for variables/functions, PascalCase for classes
+- **Error Handling**: Use specific exception handling with try/except
+- **Documentation**: Multi-line docstrings with Args/Returns sections
+- **Classes**: Prefix private methods with underscore (_)
+- **Testing**: Use pytest fixtures for reusable test components
+
+Set `PROJECT_ENV=dev` for development mode (uses cached files) or `PROJECT_ENV=prod` for production.
+
+## Architecture
+
+**Pipeline (run once daily via cron):**
+1. `ArxivClient.retrieve_daily_results()` — fetches today's papers from arXiv RSS feeds (`rss.arxiv.org/rss/{category}`), one request per category, deduplicates across categories, filters to the most recent pubDate only
+2. `FileHandler` — in dev mode, caches paper list to `papers-YYYY-MM-DD.pkl` in `PROJECT_DIR`
+3. `Agent.identify_important_papers()` — batches papers, calls Gemini (`gemini-3.1-flash-lite`) to produce a thematic markdown summary with inline `[Title](url)` links; sleeps 30s between batches to respect free-tier rate limits
+4. `create_blogpost()` — writes Jekyll markdown to `blog/_posts/YYYY-MM-DD-daily-summary.markdown`
+
+**Key env vars (`api/.env`):**
+- `GEMINI_API_KEY` — Gemini API key
+- `PROJECT_DIR` — absolute path to repo root (where pkl files are saved)
+- `PROJECT_ENV` — `dev` or `prod`
+
+**RSS categories:** `cs.LG`, `cs.AI`, `cs.CL`, `cs.CV`
+
+**Virtual env:** `.venv/` in repo root

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ This project automatically retrieves, analyzes, and summarizes the latest Machin
 You can see the resulting site online at: <https://paperpulse.ukurup.com>
 
 ## Features
-- Daily retrieval of new papers from ArXiv in ML, AI, CV, and CL categories
-- Automatic thematic grouping and summarization of papers using OpenAI API
-- Generation of blog posts with summaries and hyperlinked references using Jekyll
+- Daily retrieval of new papers from arXiv RSS feeds (one request per category, no pagination)
+- Automatic thematic grouping and summarization using Google Gemini (`gemini-3.1-flash-lite`)
+- Blog posts with inline hyperlinks — every paper mentioned links directly to its arXiv page
+- Generation of blog posts using Jekyll
 
 ### TODO
 - Identification of top papers based on a simple recommendation engine
@@ -14,81 +15,89 @@ You can see the resulting site online at: <https://paperpulse.ukurup.com>
 
 ## Main Requirements
 - Python 3.x
-- Jekyll 
-- OpenAI API key
+- Jekyll
+- Google Gemini API key
 
 ## Installation
 Creating a virtual env first is recommended
 ```
 git clone [repository-url]
 cd paperpulse
-pip install -r requirements.txt 
+pip install -r api/requirements.txt
 ```
 
-## Set up environment variables:
-Create a .env file in the root directory with the following variables:
+## Set up environment variables
+Create a `.env` file in the `api/` directory with the following variables:
 ```
-OPENAI_API_KEY=[your-openai-api-key]
-PROJECT_ENV=dev  # or 'prod' for production. 
-PROJECT_DIR=[path-to-project-directory]
+GEMINI_API_KEY=[your-gemini-api-key]
+PROJECT_ENV=dev  # or 'prod' for production
+PROJECT_DIR=[absolute-path-to-project-root]
 ```
 
-In `dev` mode, when `main.py` is run, the paper info retrieved via the ArXiv API is stored to the file `papers-<today's date>.pkl` in `PROJECT_DIR`. If `main.py` run again, info from this file is used instead of pinging the ArXiv API once more.
+In `dev` mode, when `main.py` is run, the retrieved paper list is saved to `papers-<today's date>.pkl` in `PROJECT_DIR`. On subsequent runs the cached file is used instead of re-fetching from arXiv.
 
 ## Usage
 
-### To generate daily summaries: 
-`python main.py`
+### To generate daily summaries
+```
+PYTHONPATH=. .venv/bin/python -m api.main
+```
 
 This will:
-- Retrieve the latest paper info (title, authors, abstract) from ArXiv
-- Process and analyze this info to generate thematic summaries
-- Create a blog post in the blog/_posts directory
+- Fetch today's papers from arXiv RSS feeds (`rss.arxiv.org/rss/{category}`)
+- Batch and summarize papers using Gemini, with inline `[Title](url)` links
+- Write a blog post to `blog/_posts/YYYY-MM-DD-daily-summary.markdown`
 
-### To start the jekyll server: 
-`docker compose up --build`
+### To start the Jekyll server
+```
+docker compose up --build
+```
 
-This will:
-- start a server at localhost:4000 that shows the blog.
+This starts a server at `localhost:4000` showing the blog.
 
-If you want to deploy this blog in a more prod environment, you can set `PROJECT_ENV=prod` and use `docker-compose -f docker-compose.prod.yml up -d` but you will have to set up *nginx* and *SSL* first. You'll also have to create a cron job that runs `python main.py` once a day.
+For production, set `PROJECT_ENV=prod` and use:
+```
+docker-compose -f docker-compose.prod.yml up -d
+```
+You will need to set up *nginx* and *SSL* first, and create a cron job to run `api.main` once a day.
 
 ### Tests
-`pytest api/tests/test_main.py`
+```
+PYTHONPATH=. .venv/bin/python -m pytest api/tests/test_main.py
+```
 
 ## Development vs Production
 
-### Development mode (PROJECT_ENV=dev):
-- Saves retrieved papers to pickle files for faster development
-- Enables additional debugging output
+### Development mode (PROJECT_ENV=dev)
+- Saves retrieved papers to a pickle file for faster iteration
+- On re-run, loads papers from the pickle file instead of hitting arXiv
 
-### Production mode (PROJECT_ENV=prod):
-- Always retrieves papers directly from ArXiv
+### Production mode (PROJECT_ENV=prod)
+- Always fetches fresh papers from arXiv RSS feeds
 - Minimizes debug output
-- Optimized for production deployment
 
 ## Project Structure
 `/api`
-- `main.py`: simple orchestrator
-- `arxiv_client.py`: Handles the ArXiv API call
-- `agent.py`: OpenAI API integration for paper analysis
-- `file_handler.py`: Save and load paper info from disk
-- `utils.py`: Utility functions for PDF processing and text manipulation
-- `webs.py`: generated `.md` files used by Jekyll to make the blog
-- `settings.py`: Configuration and prompt templates
-- `tests/test_main.py`: Unit tests of core functionality
+- `main.py`: pipeline orchestrator
+- `arxiv_client.py`: fetches papers from arXiv RSS feeds
+- `agent.py`: Gemini API integration for thematic summarization
+- `file_handler.py`: save and load paper info from disk
+- `utils.py`: utility functions for PDF processing and text manipulation
+- `webs.py`: writes Jekyll `.md` blog post files
+- `settings.py`: configuration, RSS categories, and prompt templates
+- `tests/test_main.py`: unit tests for core functionality
 
-`/blog`: Contains all blog (jekyll) related functionality including the daily posts that are created by running `python main.py`
+`/blog`: Jekyll site including daily posts generated by running `api.main`
 
 ## Contributing
 - Fork the repository
-- Create a feature branch (git checkout -b feature/AmazingFeature)
-- Commit your changes (git commit -m 'Add some AmazingFeature')
-- Push to the branch (git push origin feature/AmazingFeature)
+- Create a feature branch (`git checkout -b feature/AmazingFeature`)
+- Commit your changes (`git commit -m 'Add some AmazingFeature'`)
+- Push to the branch (`git push origin feature/AmazingFeature`)
 - Open a Pull Request
 
 ## License
-MIT License 
+MIT License
 
 ## Acknowledgments
-- ArXiv for providing the research paper API
+- arXiv for providing RSS feeds

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,0 +1,39 @@
+# Worklog
+
+## Session: 2026-06-03
+
+### Worked on
+Refactoring the paper retrieval pipeline and LLM integration.
+
+### Completed
+
+**Paper retrieval — switched to RSS feeds**
+- Investigated arXiv search API 429/503 errors; attempted OAI-PMH as replacement
+- Debugged OAI-PMH: `ListRecords` verb times out on all queries regardless of date range or category size; only static verbs (`Identify`, `ListSets`) work
+- Root cause: arXiv OAI-PMH docs state it does not support selective harvesting by date; our `from`/`until` params caused server-side timeouts
+- Replaced `ArxivClient` with RSS-based implementation (`rss.arxiv.org/rss/{category}`)
+- RSS feeds are a complete daily batch — one request per category, no pagination
+- Added date filtering: keeps only items matching the most recent `pubDate` in the feed, guarding against mixed-date edge cases
+- All changes on branch `refactor/oai-pmh-migration`
+
+**LLM — switched from OpenAI to Gemini**
+- OpenAI key hit quota; switched `Agent` to use `google-genai` SDK
+- Model: `gemini-3.1-flash-lite`
+- Added `GEMINI_API_KEY` env var
+- Added 30s sleep between LLM batches to respect free-tier token-per-minute limit (250k tokens/min)
+
+**Paper linking — fixed zero-link problem**
+- Root cause: `add_markdown_links` did post-hoc regex matching of LLM output against paper titles; LLM never mentioned titles verbatim so nothing matched
+- Fix: pass `**URL:**` for each paper in the prompt; instruct LLM to output `[Title](url)` links inline
+- Removed `add_markdown_links` call from pipeline; LLM now handles linking directly
+- Blog posts now contain clickable links to every paper mentioned
+
+### Decisions made
+- OAI-PMH abandoned — server-side timeouts are not fixable from the client; RSS is the right tool for daily new-paper harvesting
+- Gemini free tier has a 250k token/minute limit; 30s inter-batch sleep is sufficient for current paper volumes (~900 papers → 4 batches)
+- Inline LLM linking is more robust than post-hoc regex matching and requires no additional API calls
+
+### Next session priorities
+- Remove unused `add_markdown_links` and related helpers from `utils.py`
+- Set up cron job in prod Docker config to run the pipeline daily
+- Investigate whether `MIXPANEL_TOKEN` tracking is wired up correctly for the new blog post format

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,5 +1,43 @@
 # Worklog
 
+## Session: 2026-06-03 (continued)
+
+### Worked on
+Cleanup, dependency hygiene, and content fixes after the RSS/Gemini migration.
+
+### Completed
+
+**Ruby gem security fixes**
+- Updated `addressable` 2.8.1 → 2.9.0 and `rexml` 3.3.9 → 3.4.4 via `bundle update` inside the Jekyll Docker container
+- Fixes Dependabot alerts #9 (REXML DoS) and #11 (Addressable ReDoS); will close when branch is merged to main
+
+**Markdown heading fix**
+- Root cause: `COMBINE_PROMPT` instructed LLM to write "Theme N:" without `##`, stripping the heading markers from the per-batch summaries
+- Fix: updated `COMBINE_PROMPT` to explicitly require `## Theme N:` format
+- Verified with re-run: headings now render as bold H2 in the blog
+
+**Removed OpenAI dependency**
+- Commented out `summarize_paper`, `_create_and_run_thread`, `_combine_paper_summaries` in `agent.py` with a TODO for full removal in a later commit
+- Removed `import openai` from `agent.py` and `main.py`
+- Added `google-genai==2.7.0` and `PyMuPDF==1.27.2.3` to `requirements.txt`
+
+**What's New page**
+- Added v1.03 entry: RSS feeds, Gemini, inline paper linking
+
+**README**
+- Updated to reflect Gemini (was OpenAI), RSS feeds (was search API), correct run commands (`PYTHONPATH=. .venv/bin/python -m api.main`), and updated env vars (`GEMINI_API_KEY`)
+
+### Decisions made
+- `summarize_paper` commented out rather than deleted — preserves the OpenAI RAG approach for potential future use with a different LLM
+
+### Next session priorities
+- Merge `refactor/oai-pmh-migration` → `main` to close all 4 Dependabot alerts
+- Delete `summarize_paper` and related OpenAI methods fully (TODO already in code)
+- Set up cron job in prod Docker config to run the pipeline daily
+- Investigate whether `MIXPANEL_TOKEN` tracking is wired up correctly for the new blog post format
+
+---
+
 ## Session: 2026-06-03
 
 ### Worked on

--- a/api/agent.py
+++ b/api/agent.py
@@ -1,5 +1,3 @@
-import openai
-from openai import OpenAI
 import os
 import time
 import logging
@@ -135,165 +133,45 @@ class Agent:
         
         return final_summary
 
-    def summarize_paper(self, pdf_file):
-        """
-        Summarizing a paper is a 5 step process that uses openai's beta client / message thread 
-        approach which allows a pdf file to be uploaded. OpenAI creates a vector store that 
-        then answers queries using a RAG approach to answer questions.
-        Known Issues:
-        1. RAG approach has a max of 4000 tokens. This means asking broad questions is not possible
-        Workaround is to break up the summarization into the following sets of questions.
-                a. Summary of the paper (uses the abstract)
-                b. Related work
-                c. Approach
-                d. Results
-                e. Discussion, future work, and any relevant core papers
-            2. Images aren't supported currently so it won't be able to read and process tables, charts, images
-            or return information in that form.
+    # TODO: remove summarize_paper, _create_and_run_thread, _combine_paper_summaries in a future commit
+    # def summarize_paper(self, pdf_file):
+    #     client = OpenAI()
+    #     assistant = client.beta.assistants.create(
+    #         name="ML Research Assistant",
+    #         instructions="You are an expert ML researcher and engineer.",
+    #         model="gpt-4o-mini",
+    #         tools=[{"type": "file_search"}],
+    #     )
+    #     vector_store = client.beta.vector_stores.create(name=pdf_file)
+    #     file_streams = [open(path, "rb") for path in [pdf_file]]
+    #     client.beta.vector_stores.file_batches.upload_and_poll(
+    #         vector_store_id=vector_store.id, files=file_streams
+    #     )
+    #     assistant = client.beta.assistants.update(
+    #         assistant_id=assistant.id,
+    #         tool_resources={"file_search": {"vector_store_ids": [vector_store.id]}},
+    #     )
+    #     summaries = []
+    #     for prompt in [
+    #         "Provide a summary of under 500 words of this paper for an audience of ML research scientists.",
+    #         "Provide a summary of the related work that is referenced in this paper.",
+    #         "Provide a summary of the approach that the authors present in the paper.",
+    #         "Provide a summary of the results in the paper.",
+    #         "Provide a summary of any discussion, conclusion, and future work sections in the paper.",
+    #     ]:
+    #         messages = self._create_and_run_thread(client, prompt, assistant.id)
+    #         summaries.append(messages[0].content[0].text.value)
+    #     ids = [store.id for store in openai.beta.vector_stores.list()]
+    #     for id in ids:
+    #         client.beta.vector_stores.delete(id)
+    #     return self._combine_paper_summaries(summaries)
 
-        Args:
-            pdf_file (str): file path to the downloaded pdf file
+    # def _create_and_run_thread(self, client, content, assistant_id):
+    #     thread = client.beta.threads.create(messages=[{"role": "user", "content": content}])
+    #     run = client.beta.threads.runs.create_and_poll(thread_id=thread.id, assistant_id=assistant_id)
+    #     return list(client.beta.threads.messages.list(thread_id=thread.id, run_id=run.id))
 
-        Returns:
-            summary (str): A summary that combines the answers to the above questions.
-        """
-
-        client = OpenAI()
-
-        assistant = client.beta.assistants.create(
-            name="ML Research Assistant",
-            instructions="You are an expert ML researcher and engineer.",
-            model="gpt-4o-mini",
-            tools=[{"type": "file_search"}],
-        )
-
-        vector_store = client.beta.vector_stores.create(name=pdf_file)
-
-        # Ready the files for upload to OpenAI
-        file_paths = [pdf_file]
-        file_streams = [open(path, "rb") for path in file_paths]
-
-        # Use the upload and poll SDK helper to upload the files, add them to the vector store,
-        # and poll the status of the file batch for completion.
-        file_batch = client.beta.vector_stores.file_batches.upload_and_poll(
-            vector_store_id=vector_store.id, files=file_streams
-        )
-
-        assistant = client.beta.assistants.update(
-            assistant_id=assistant.id,
-            tool_resources={"file_search": {"vector_store_ids": [vector_store.id]}},
-        )
-
-        # first the summary
-        print('Generating high-level summary...')
-        summaries = []
-        messages = self._create_and_run_thread(
-            client,
-            "You are an expert ML researcher and engineer. Provide a summary of under 500 words of this paper for an audience of ML research scientists.",
-            assistant.id
-        )
-        summaries.append(messages[0].content[0].text.value)
-
-        # then the related work
-        print('Generating related work summary...')
-        messages = self._create_and_run_thread(
-            client,
-            "You are an expert ML researcher and engineer. Provide a summary of the related work that is referenced in this paper. Make the summary suitable for an audience of ML research scientists.",
-            assistant.id
-        )
-        summaries.append(messages[0].content[0].text.value)
-
-        # the approach
-        print('Generating summary of approach...')
-        messages = self._create_and_run_thread(
-            client,
-            "You are an expert ML researcher and engineer. Provide a summary of the approach that the authors present in the paper. Make the summary suitable for an audience of ML research scientists.",
-            assistant.id
-        )
-        summaries.append(messages[0].content[0].text.value)
-
-        # the results
-        print('Generating summary of results...')
-        messages = self._create_and_run_thread(
-            client,
-            "You are an expert ML researcher and engineer. Provide a summary of the results in the paper. Make the summary suitable for an audience of ML research scientists.",
-            assistant.id
-        )
-        summaries.append(messages[0].content[0].text.value)
-
-        # and finally the conclusion
-        print('Generating summary of discussion and future work...')
-        messages = self._create_and_run_thread(
-            client,
-            "You are an expert ML researcher and engineer. Provide a summary of any disucssion, conclusion, and future work sections in the paper. Make the summary suitable for an audience of ML research scientists.",
-            assistant.id
-        )
-        summaries.append(messages[0].content[0].text.value)
-
-        # try deleting the file and then list the vector stores again. 
-        # client.files.delete(os.path.basename(pdf_file))
-        ids = [store.id for store in openai.beta.vector_stores.list()]
-        for id in ids:
-            delid = client.beta.vector_stores.delete(id)
-
-        # combine all of the text into a coherent narrative
-        print('Generating full narrative ...')
-        narrative = self._combine_paper_summaries(summaries)
-
-        return narrative
-        print(f'Deleted vector stores: {ids}')
-        
-
-
-    def _create_and_run_thread(self, client, content, assistant_id):
-        """
-        Creates and runs the message thread that queries OpenAI
-
-        Args:
-            client (object): OpenAI client
-            content (str): the prompt
-            assistant_id (str): id of the assistant used in the openai call
-
-        Returns:
-            message (object): the message returned from the openai call
-        """
-
-        # Create a thread
-        thread = client.beta.threads.create(
-            messages=[
-                {
-                    "role": "user",
-                    "content": content,
-                }
-            ]
-        )
-
-        run = client.beta.threads.runs.create_and_poll(
-            thread_id=thread.id,
-            assistant_id=assistant_id)
-
-        messages = list(client.beta.threads.messages.list(thread_id=thread.id, run_id=run.id))
-
-        return messages
-
-    def _combine_paper_summaries(self, summaries):
-        """
-        Combine the separate summaries of the paper into one coherent narrative
-
-        Args:
-            summaries (list): a list of the different summaries
-
-        Returns:
-            str: a summary that combines the different summaries
-        """
-
-        prompt = """ You are an accomplished AI and Machine Learning research scientist and educator. 
-        You are also an expert English proof reader and summarizer who can explain concepts.
-        Take all of the information below the heading SUMMARIES and convert that text into a coherent 
-        narrative that's short, compact, and easy to read. 
-
-        SUMMARIES
-
-        """
-        prompt = prompt + ''.join(summaries)
-        return self._call_llm(prompt)
+    # def _combine_paper_summaries(self, summaries):
+    #     prompt = ("You are an ML research scientist. Convert the following summaries into a coherent "
+    #               "narrative that's short, compact, and easy to read.\n\nSUMMARIES\n\n")
+    #     return self._call_llm(prompt + ''.join(summaries))

--- a/api/agent.py
+++ b/api/agent.py
@@ -1,20 +1,21 @@
-# Contains all of the Open AI calls
 import openai
 from openai import OpenAI
 import os
+import time
 import logging
 
-from api.settings import SUMMARY_PROMPT, COMBINE_PROMPT
+from google import genai
+from google.genai import types
 
-openai.api_key = os.getenv("OPENAI_API_KEY")
+from api.settings import SUMMARY_PROMPT, COMBINE_PROMPT
 
 logger = logging.getLogger(__name__)
 
 
 
 class Agent:
-    def __init__(self, openai_api_key):
-        openai.api_key = openai_api_key
+    def __init__(self, gemini_api_key):
+        self.client = genai.Client(api_key=gemini_api_key)
 
     def _combine_paper_info(self, paper):
         """
@@ -23,7 +24,7 @@ class Agent:
         Args:
         paper: the dict containing details of the paper
         """
-        return f"**Title:** {paper['title']}\n**Authors:** {', '.join(paper['authors'])}\n**Summary:** {paper['summary']}\n"
+        return f"**Title:** {paper['title']}\n**URL:** {paper['url']}\n**Authors:** {', '.join(paper['authors'])}\n**Summary:** {paper['summary']}\n"
 
     def _batch_papers(self, papers, max_length, prompt_template):
         """
@@ -61,36 +62,18 @@ class Agent:
         logger.info(f"Split {len(papers)} papers into {len(batches)} batches")
         return batches
 
-    def _call_llm(self, prompt, max_tokens = 5000):
-        """
-        Helper function to make LLM API calls.
-        
-        Args:
-            prompt: The prompt to send to the LLM
-            max_tokens: Maximum tokens for the response
-            
-        Returns:
-            The LLM's response text
-        
-        Raises:
-            Exception: If the API call fails
-        """
+    def _call_llm(self, prompt, max_tokens=5000):
         try:
-            messages = [
-                {"role": "system", "content": "You are a helpful assistant."},
-                {"role": "user", "content": prompt}
-            ]
-            
-            response = openai.chat.completions.create(
-                model="gpt-4o-mini",
-                messages=messages,
-                max_tokens=max_tokens,
-                temperature=0.1,
-                top_p=0.9
+            response = self.client.models.generate_content(
+                model='gemini-3.1-flash-lite',
+                contents=prompt,
+                config=types.GenerateContentConfig(
+                    system_instruction='You are a helpful assistant.',
+                    temperature=0.1,
+                    max_output_tokens=max_tokens,
+                )
             )
-            
-            return response.choices[0].message.content
-            
+            return response.text
         except Exception as e:
             logger.error(f"LLM API call failed: {str(e)}")
             raise
@@ -121,20 +104,21 @@ class Agent:
         # Process each batch
         for i, batch in enumerate(batches, 1):
             logger.info(f"Processing batch {i} of {len(batches)}")
-            
+
             # Combine papers in this batch
             batch_info = "\n".join(self._combine_paper_info(p) for p in batch)
             prompt = SUMMARY_PROMPT + batch_info
-            
+
             try:
-                # Get summary for this batch
                 batch_summary = self._call_llm(prompt)
                 intermediate_summaries.append(batch_summary)
                 logger.info(f"Successfully processed batch {i}")
-                
             except Exception as e:
                 logger.error(f"Failed to process batch {i}: {str(e)}")
                 continue
+
+            if i < len(batches):
+                time.sleep(30)
         
         # If we have multiple summaries, combine them
         if len(intermediate_summaries) > 1:
@@ -312,21 +296,4 @@ class Agent:
 
         """
         prompt = prompt + ''.join(summaries)
-
-        # get summaries
-        messages = [
-            {"role": "system", "content": "You are a helpful assistant."},
-            {"role": "user", "content": prompt}
-        ]
-
-        # Call the OpenAI API
-        response = openai.chat.completions.create(
-            model="gpt-4o-mini", 
-            messages=messages,
-            max_tokens=5000, 
-            temperature=0.1,
-            top_p=0.9,  # Adjust as needed
-        )
-
-        # Extract the paper titles from the response
-        return(response.choices[0].message.content)
+        return self._call_llm(prompt)

--- a/api/arxiv_client.py
+++ b/api/arxiv_client.py
@@ -1,155 +1,118 @@
 import time
 import logging
 import re
-import urllib
 import urllib.request as libreq
 
 import xml.etree.ElementTree as ET
+from email.utils import parsedate_to_datetime
 
-from datetime import datetime, date, timedelta, timezone
+from api.settings import RSS_CATEGORIES
 
 logger = logging.getLogger(__name__)
 
+_RSS_NS = {
+    'dc': 'http://purl.org/dc/elements/1.1/',
+    'arxiv': 'http://arxiv.org/schemas/atom',
+}
+
 class ArxivClient:
-    def __init__(self, 
-                 search_query='cat:cs.LG+OR+cat:cs.AI+OR+cat:cs.CL+OR+cat:cs.CV',
-                 sort_by='lastUpdatedDate',
-                 sort_order='descending'):
-        
-        # Define the search query and sorting parameters
-        self.search_query = search_query
-        self.sort_by = sort_by
-        self.sort_order = sort_order
+    def __init__(self, categories=RSS_CATEGORIES):
+        self.categories = categories
+        self.base_url = 'https://rss.arxiv.org/rss'
 
-    def _process_paper_entry(self, entry):
-        """
-        Parses the data retrieved by the ArXiV API call, extracts information, and populates a dict
+    def _process_paper_entry(self, item):
+        title = (item.findtext('title') or '').strip()
+        url = (item.findtext('link') or '').strip()
 
-        Args:   
-            entry: an XML string
+        # description format: "arXiv:XXXX.XXXXvN Announce Type: TYPE Abstract: [text]"
+        description = item.findtext('description') or ''
+        abstract_match = re.search(r'Abstract:\s*(.*)', description, re.DOTALL)
+        summary = abstract_match.group(1).strip() if abstract_match else description.strip()
 
-        Returns:
-            dict: containing the parsed values
-        """
-        affiliations = []
-        paper = {}
-        paper['title'] = entry.find('{http://www.w3.org/2005/Atom}title').text
-        paper['authors'] = [author.find('{http://www.w3.org/2005/Atom}name').text 
-                    for author in entry.findall('{http://www.w3.org/2005/Atom}author')]
-        for author in entry.findall('{http://www.w3.org/2005/Atom}author'):
-            affiliation_element = author.find('{http://arxiv.org/schemas/atom}affiliation')
-            if affiliation_element is not None:
-                affiliations.append(affiliation_element.text)
-        paper['summary'] = entry.find('{http://www.w3.org/2005/Atom}summary').text
-        paper['url'] = entry.find('{http://www.w3.org/2005/Atom}id').text
+        # dc:creator contains all authors comma-separated
+        creator = item.findtext('dc:creator', namespaces=_RSS_NS) or ''
+        authors = [a.strip() for a in creator.split(',') if a.strip()]
 
-        return paper
+        return {
+            'title': title,
+            'authors': authors,
+            'summary': summary,
+            'url': url,
+        }
 
     def retrieve_daily_results(self):
-        """
-        Retrieves all result for the last day.
-        Retrieves results 10 at a time, starting from a week ago and continuing
-        till the latest paper is retrieved. 
-
-        Args:
-            None
-
-        Returns:
-            list: list of dicts (title, authors, summary, url) of parsed information about papers.
-        """
         papers = []
-        # Define the desired timezone - using UTC for consistency
-        desired_timezone = timezone.utc 
+        seen_urls = set()
+        max_retries = 5
 
-        # Calculate the date one week ago in the desired timezone
-        #currdate = datetime.now(desired_timezone)
-        #print(f'Current datetime: {currdate}')
-        #one_day_ago = currdate - timedelta(days=1)
-        #print(f'Retrieving results for {one_day_ago}')
-        one_day_ago = None
+        for i, category in enumerate(self.categories):
+            if i > 0:
+                time.sleep(3)
 
-        start = 0
-        max_results = 50  
-        max_retries = 5 # sometimes the API fails, so retry 3 times and only then give up.
+            url = f'{self.base_url}/{category}'
+            root = None
 
-        while True:
-            url = f'http://export.arxiv.org/api/query?search_query={self.search_query}&sortBy={self.sort_by}&sortOrder={self.sort_order}&start={start}&max_results={max_results}'
-            
-            retry_count = 0
-            while retry_count < max_retries:
+            for attempt in range(1, max_retries + 1):
                 try:
-                    with libreq.urlopen(url) as response:
-                        data = response.read()
-                        root = ET.fromstring(data)
-
-                        # Check if any entries were returned
-                        if len(root.findall('{http://www.w3.org/2005/Atom}entry')) == 0:
-                            retry_count += 1
-                            if retry_count == max_retries:
-                                print(f"No data in returned XML after {max_retries} attempts")
-                                xml_str = ET.tostring(root, encoding='unicode', method='xml')
-                                print(f'Full xml = {xml_str}')
-                                return papers
-                            print(f"No data in returned XML, attempt {retry_count} of {max_retries}")
-                            time.sleep(10)  # Wait 10 seconds before retrying
-                            continue
-                        
-                        # If we get here, we have data, so break the retry loop
-                        break
+                    with libreq.urlopen(url, timeout=30) as response:
+                        root = ET.fromstring(response.read())
+                    break
                 except Exception as e:
-                    retry_count += 1
-                    if retry_count == max_retries:
-                        print(f"Failed to retrieve data after {max_retries} attempts: {str(e)}")
-                        return papers
-                    print(f"Error on attempt {retry_count}: {str(e)}")
-                    time.sleep(5)
-                    continue
+                    if attempt == max_retries:
+                        print(f"Failed to fetch {category} after {max_retries} attempts: {e}")
+                    else:
+                        print(f"Attempt {attempt} error for {category}: {e}")
+                        time.sleep(5)
 
-            for entry in root.findall('{http://www.w3.org/2005/Atom}entry'):
-                updated_date_str = entry.find('{http://www.w3.org/2005/Atom}updated').text
-                #print(updated_date_str)
-                updated_date = datetime.strptime(updated_date_str, '%Y-%m-%dT%H:%M:%S%z')
+            if root is None:
+                continue
 
-                # Make sure updated_date is in the desired timezone
-                updated_date = updated_date.astimezone(desired_timezone) 
+            items = root.findall('.//item')
 
-                if not one_day_ago:
-                    one_day_ago = updated_date - timedelta(days=1)
-                    print(f'Retrieving new/updated papers till : {one_day_ago}')
-                
-                if updated_date > one_day_ago:
-                    papers.append(self._process_paper_entry(entry))
-                else:
-                    # Stop processing since entries are sorted by last updated date
-                    print(f'Current: {updated_date}. Up to: {one_day_ago}')
-                    papers.append(self._process_paper_entry(entry))
-                    return papers
+            # Find the most recent pubDate in this feed and keep only items from that date.
+            # Guards against mixed-date feeds and partial intra-day data.
+            pub_dates = []
+            for item in items:
+                raw = item.findtext('pubDate')
+                if raw:
+                    try:
+                        pub_dates.append(parsedate_to_datetime(raw).date())
+                    except Exception:
+                        pass
 
-            # Increment start index for the next batch
-            start += max_results
-            print(f'latest date: {updated_date}')
-            time.sleep(5)
-            if start>1200: # never retrieve more than 1600 results
-                print('Found more than 1200 papers')
-                break
-        
+            latest_date = max(pub_dates) if pub_dates else None
+
+            for item in items:
+                if latest_date:
+                    raw = item.findtext('pubDate')
+                    try:
+                        item_date = parsedate_to_datetime(raw).date()
+                        if item_date != latest_date:
+                            continue
+                    except Exception:
+                        pass
+
+                paper = self._process_paper_entry(item)
+                if paper and paper['url'] not in seen_urls:
+                    seen_urls.add(paper['url'])
+                    papers.append(paper)
+
         return papers
-    
+
     def extract_titles(self, content):
         """
         Extracts titles from the content using regex.
-        
+
         Titles are assumed to follow the pattern:
         - A number followed by a period (`1.`, `2.`, etc.)
         - The title is enclosed in double asterisks (`**`).
-        
+
         Args:
             content (str): The string content containing the top 5 papers selected by the LLM.
-        
+
         Returns:
             list: A list of titles extracted from the content.
         """
-        # Match lines starting with a number followed by a title in double asterisks
         matches = re.findall(r"\d+\.\s\*\*(.*?)\*\*", content)
         return matches
 
@@ -166,16 +129,10 @@ class ArxivClient:
             list: Filtered dictionaries that match the titles.
         """
         def normalize(text):
-            # Remove special characters and extra whitespace
             return re.sub(r'\s+', ' ', text.strip()).replace('\n', '')
 
-        # Normalize extracted titles for comparison
         normalized_titles = [normalize(title) for title in titles]
-
-        # Filter dictionaries whose normalized title matches any in the normalized titles
         return [item for item in dict_list if normalize(item.get('title', '')) in normalized_titles]
-
-        
 
     def get_pdf_url(self, arxiv_url):
         """
@@ -187,44 +144,30 @@ class ArxivClient:
         Returns:
             str: The URL of the PDF, or None if not found.
         """
-
-        # 1. Extract the arXiv ID from the URL
         match = re.search(r'abs/([\w\.\/]+)', arxiv_url)
         if not match:
             return None
         arxiv_id = match.group(1)
 
-        # 2. Construct the API query URL
         api_url = f'http://export.arxiv.org/api/query?id_list={arxiv_id}'
 
         try:
-            # 3. Call the API and get the Atom feed
             with libreq.urlopen(api_url) as response:
                 xml_content = response.read()
 
-            # 4. Parse the Atom feed
             tree = ET.fromstring(xml_content)
 
-            # Register the namespaces
             namespaces = {
                 'atom': 'http://www.w3.org/2005/Atom',
                 'arxiv': 'http://arxiv.org/schemas/atom'
             }
 
-            # 5. Find the PDF link
             for entry in tree.findall('atom:entry', namespaces):
                 for link in entry.findall('atom:link', namespaces):
                     if link.get('rel') == 'related' and link.get('title') == 'pdf':
                         return link.get('href')
             return None
 
-
-        except urllib.error.URLError as e:
-            logger.error(f"Error: Could not retrieve data from the API. {e}")
-            return None
-        except ET.ParseError as e:
-            logger.error(f"Error: Could not parse the XML data. {e}")
-            return None
         except Exception as e:
             logger.error(f"An unexpected error occurred {e}")
             return None

--- a/api/main.py
+++ b/api/main.py
@@ -12,15 +12,14 @@ import xml.etree.ElementTree as ET
 
 from dotenv import load_dotenv
 from api.utils import (
-    extract_text_from_pdf, 
+    extract_text_from_pdf,
     extract_images_from_pdf_base64,
     download_pdf,
-    add_markdown_links
-    )
+)
 from api.arxiv_client import ArxivClient
 from api.agent import Agent
 from api.file_handler import FileHandler
-from api.settings import ARXIV_SEARCH_QUERY, ARXIV_SORT_BY, ARXIV_SORT_ORDER
+from api.settings import RSS_CATEGORIES
 
 from api.webs import create_blogpost
 
@@ -39,8 +38,8 @@ def main():
     logger.info(dev_env)
 
     # initalize
-    arxiv_client = ArxivClient(ARXIV_SEARCH_QUERY, ARXIV_SORT_BY, ARXIV_SORT_ORDER)
-    llm_agent = Agent(os.getenv("OPENAI_API_KEY"))
+    arxiv_client = ArxivClient(RSS_CATEGORIES)
+    llm_agent = Agent(os.getenv("GEMINI_API_KEY"))
     file_handler = FileHandler(os.getenv("PROJECT_DIR"))
     papers = None
 
@@ -68,11 +67,7 @@ def main():
         print(f'Exception: {e}')
         return
 
-    # link papers mentioned in the summary to Arxiv
-    summary_linked = add_markdown_links(summary, papers)
-
-    # write the smummary to a web page based on the day when the papers were retrieved
-    create_blogpost(summary_linked, len(papers))
+    create_blogpost(summary, len(papers))
 
 if __name__ == "__main__":
     main()

--- a/api/main.py
+++ b/api/main.py
@@ -1,5 +1,4 @@
 import os
-import openai
 import pickle
 import re
 import logging

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,5 +1,5 @@
-Flask==2.3.3
+Flask==3.1.3
 Flask-SQLAlchemy==3.1.1
-python-dotenv==1.0.0
+python-dotenv==1.2.2
 gunicorn==23.0.0
 psycopg2-binary==2.9.9  # For PostgreSQL

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -2,4 +2,6 @@ Flask==3.1.3
 Flask-SQLAlchemy==3.1.1
 python-dotenv==1.2.2
 gunicorn==23.0.0
-psycopg2-binary==2.9.9  # For PostgreSQL
+psycopg2-binary==2.9.9
+google-genai==2.7.0
+PyMuPDF==1.27.2.3

--- a/api/settings.py
+++ b/api/settings.py
@@ -11,7 +11,7 @@ For each theme:
 1. Use a clear, descriptive heading (e.g., "Theme 1: Modeling & Optimization")
 2. Highlight the most important developments and insights within that theme
 3. Mention specific papers when relevant to illustrate points
-4. If you mention specific papers, make sure to mention the complete title
+4. When mentioning a paper, you MUST format it as a markdown hyperlink using the URL provided: [Full Paper Title](url). Always use the complete title as the link text.
 5. Show how papers within the theme connect to each other
 
 Write about each theme starting directly with "Theme 1:". Do not include any introductory text before Theme 1.
@@ -34,7 +34,8 @@ COMBINE_PROMPT = """
         Your summaries and explanations of concepts and papers in machine learning and artificial intelligence are like
         how Neil Degrasse Tyson and Carl Sagan explain astronomy and cosmology concepts.  
         You are tasked with combining multiple research summaries into a single coherent summary. 
-        Please combine the following summaries, maintaining the thematic organization and removing any redundancy. 
+        Please combine the following summaries, maintaining the thematic organization and removing any redundancy.
+        Preserve all existing markdown hyperlinks exactly as they appear — do not remove or reformat any [Title](url) links.
         Write about each theme starting directly with "Theme 1:". Do not include any introductory text before Theme 1.:\n\n
         """
 
@@ -48,6 +49,4 @@ Select exactly five papers that you believe represent the most significant or gr
 List of Papers and Abstracts
 """
 
-ARXIV_SEARCH_QUERY='cat:cs.LG+OR+cat:cs.AI+OR+cat:cs.CL+OR+cat:cs.CV'
-ARXIV_SORT_BY='lastUpdatedDate'
-ARXIV_SORT_ORDER='descending'
+RSS_CATEGORIES = ['cs.LG', 'cs.AI', 'cs.CL', 'cs.CV']

--- a/api/settings.py
+++ b/api/settings.py
@@ -36,7 +36,7 @@ COMBINE_PROMPT = """
         You are tasked with combining multiple research summaries into a single coherent summary. 
         Please combine the following summaries, maintaining the thematic organization and removing any redundancy.
         Preserve all existing markdown hyperlinks exactly as they appear — do not remove or reformat any [Title](url) links.
-        Write about each theme starting directly with "Theme 1:". Do not include any introductory text before Theme 1.:\n\n
+        Format each theme heading as "## Theme N: [Theme Name]". Do not include any introductory text before Theme 1.:\n\n
         """
 
 TOP5_PAPERS_PROMPT = """

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -22,7 +22,7 @@ def arxiv_client():
 
 @pytest.fixture
 def llm_agent():
-    return Agent(openai_api_key="dummy_key")
+    return Agent(gemini_api_key="dummy_key")
 
 @pytest.fixture
 def file_handler():
@@ -40,40 +40,34 @@ def sample_paper():
 @pytest.fixture
 def sample_entry():
     xml_string = """
-    <entry xmlns="http://www.w3.org/2005/Atom">
+    <item>
         <title>Test Paper Title</title>
-        <author>
-            <name>Author One</name>
-        </author>
-        <author>
-            <name>Author Two</name>
-        </author>
-        <summary>This is a test summary</summary>
-        <id>https://arxiv.org/abs/1234.5678</id>
-        <updated>2025-01-17T12:00:00Z</updated>
-    </entry>
+        <link>https://arxiv.org/abs/1234.5678</link>
+        <description>arXiv:1234.5678v1 Announce Type: new Abstract: This is a test summary</description>
+        <dc:creator xmlns:dc="http://purl.org/dc/elements/1.1/">Author One, Author Two</dc:creator>
+    </item>
     """
     return ET.fromstring(xml_string)
 
 @pytest.fixture
 def mock_arxiv_response():
-    return """<?xml version="1.0" encoding="UTF-8"?>
-    <feed xmlns="http://www.w3.org/2005/Atom">
-        <entry>
-            <title>Test Paper 1</title>
-            <author><name>Author One</name></author>
-            <summary>Summary 1</summary>
-            <id>https://arxiv.org/abs/1234.5678</id>
-            <updated>2025-01-17T12:00:00Z</updated>
-        </entry>
-        <entry>
-            <title>Test Paper 2</title>
-            <author><name>Author Two</name></author>
-            <summary>Summary 2</summary>
-            <id>https://arxiv.org/abs/8765.4321</id>
-            <updated>2025-01-17T11:00:00Z</updated>
-        </entry>
-    </feed>
+    return b"""<?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0" xmlns:dc="http://purl.org/dc/elements/1.1/">
+      <channel>
+        <item>
+          <title>Test Paper 1</title>
+          <link>https://arxiv.org/abs/1234.5678</link>
+          <description>arXiv:1234.5678v1 Announce Type: new Abstract: Summary 1</description>
+          <dc:creator>Author One</dc:creator>
+        </item>
+        <item>
+          <title>Test Paper 2</title>
+          <link>https://arxiv.org/abs/8765.4321</link>
+          <description>arXiv:8765.4321v1 Announce Type: new Abstract: Summary 2</description>
+          <dc:creator>Author Two</dc:creator>
+        </item>
+      </channel>
+    </rss>
     """
 
 # ArxivClient Tests
@@ -85,16 +79,18 @@ class TestArxivClient:
         assert result['summary'] == 'This is a test summary'
         assert result['url'] == 'https://arxiv.org/abs/1234.5678'
 
-    #@patch('urllib.request.urlopen')
-    #def test_retrieve_daily_results(self, mock_urlopen, arxiv_client, mock_arxiv_response):
-    #    mock_response = Mock()
-    #    mock_response.read.return_value = mock_arxiv_response.encode()
-    #    mock_urlopen.return_value.__enter__.return_value = mock_response
+    @patch('urllib.request.urlopen')
+    def test_retrieve_daily_results(self, mock_urlopen, mock_arxiv_response):
+        mock_response = Mock()
+        mock_response.read.return_value = mock_arxiv_response
+        mock_urlopen.return_value.__enter__.return_value = mock_response
 
-    #    results = arxiv_client.retrieve_daily_results()
-    #    assert len(results) == 2
-    #    assert results[0]['title'] == 'Test Paper 1'
-    #    assert results[1]['title'] == 'Test Paper 2'
+        client = ArxivClient(categories=['cs.LG'])
+        with patch('time.sleep'):
+            results = client.retrieve_daily_results()
+        assert len(results) == 2
+        assert results[0]['title'] == 'Test Paper 1'
+        assert results[1]['title'] == 'Test Paper 2'
 
     @patch('urllib.request.urlopen')
     def test_get_pdf_url(self, mock_urlopen, arxiv_client):
@@ -136,13 +132,9 @@ class TestArxivClient:
 
 # Agent Tests
 class TestAgent:
-    @patch('openai.chat.completions.create')
-    def test_identify_important_papers(self, mock_openai, llm_agent):
+    def test_identify_important_papers(self, llm_agent):
         mock_response = Mock()
-        mock_response.choices = [
-            Mock(message=Mock(content="Summary content\n\nTop 5 papers content"))
-        ]
-        mock_openai.return_value = mock_response
+        mock_response.text = "Summary content"
 
         papers = [
             {
@@ -152,13 +144,14 @@ class TestAgent:
                 'url': 'https://arxiv.org/abs/1234.5678'
             }
         ]
-        
-        summary = llm_agent.identify_important_papers(papers)
-        assert summary == "Summary content\n\nTop 5 papers content"
+
+        with patch.object(llm_agent.client.models, 'generate_content', return_value=mock_response):
+            summary = llm_agent.identify_important_papers(papers)
+        assert summary == "Summary content"
 
     def test_combine_paper_info(self, sample_paper, llm_agent):
         result = llm_agent._combine_paper_info(sample_paper)
-        expected = "**Title:** Test Paper Title\n**Authors:** Author One, Author Two\n**Summary:** This is a test summary\n"
+        expected = "**Title:** Test Paper Title\n**URL:** https://arxiv.org/abs/1234.5678\n**Authors:** Author One, Author Two\n**Summary:** This is a test summary\n"
         assert result == expected
 
 # FileHandler Tests

--- a/blog/Gemfile.lock
+++ b/blog/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.1)
-      public_suffix (>= 2.0.2, < 6.0)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.10)
     em-websocket (0.5.3)
@@ -66,11 +66,11 @@ GEM
       jekyll-seo-tag (~> 2.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.0.0)
+    public_suffix (6.0.2)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rexml (3.3.9)
+    rexml (3.4.4)
     rouge (3.30.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)

--- a/blog/whatsnew.markdown
+++ b/blog/whatsnew.markdown
@@ -3,6 +3,11 @@ layout: page
 title: What's New
 permalink: /whatsnew/
 ---
+#### v1.03
+- Switched paper retrieval to arXiv RSS feeds for more reliable daily harvesting
+- Switched LLM summarization from OpenAI to Google Gemini (`gemini-3.1-flash-lite`)
+- Papers are now linked inline within the summary — every paper mentioned links directly to its arXiv page
+
 #### v1.02
 - Added a *buy me a coffee* link
 


### PR DESCRIPTION
 Refactor paper retrieval, switch to Gemini, and dependency cleanup

  This PR replaces the arXiv search API with RSS feeds, switches the LLM provider from OpenAI to Google Gemini, and fixes several
  reliability and security issues accumulated since the initial release.

  ---
  What changed and why

  Paper retrieval — RSS feeds

  The arXiv search API was returning frequent 429/503 errors. OAI-PMH was investigated as an alternative but abandoned — arXiv's
  OAI-PMH implementation does not support selective harvesting by date, causing server-side timeouts on any ListRecords query. RSS
  feeds (rss.arxiv.org/rss/{category}) are the right tool for daily harvesting: one request per category, no pagination, inherently
  scoped to the current day. Date filtering on pubDate guards against mixed-date edge cases.

  LLM — Google Gemini

  Switched Agent from OpenAI (gpt-4o-mini) to Google Gemini (gemini-3.1-flash-lite) using the google-genai SDK. The summarize_paper
  method and its OpenAI Assistants API dependencies have been commented out with a TODO for full removal in a follow-up commit. A
  30s inter-batch sleep respects Gemini's free-tier token-per-minute limit.

  Paper linking

  The previous approach used post-hoc regex to match LLM output against paper titles. This produced zero links in practice because
  the LLM rarely quoted titles verbatim. The fix passes each paper's URL in the prompt and instructs the LLM to output [Title](url)
  links inline. No additional API calls required.

  Heading format fix

  The COMBINE_PROMPT was stripping ## heading markers from per-batch summaries by instructing the LLM to write "Theme N:" as plain
  text. Updated to explicitly require ## Theme N: format.

  Security

  - Flask 2.3.3 → 3.1.3 (Vary: Cookie CVE)
  - python-dotenv 1.0.0 → 1.2.2 (symlink following CVE)
  - addressable 2.8.1 → 2.9.0 (ReDoS)
  - rexml 3.3.9 → 3.4.4 (DoS)

  Closes Dependabot alerts #9, #11, and the two Python package alerts.

  ---
  Testing

  - All 11 unit tests passing
  - Pipeline smoke-tested end-to-end using cached pickle file; blog post generated with correct ## headings and inline paper links