### PR TITLE
Feat/ci cd pipeline

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,11 @@
 certbot/
 .env
 *.env
+*.log
+*.pkl
+blog/_site/
+blog/.jekyll-cache/
+.venv/
+__pycache__/
+*.pyc
+.pytest_cache/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,7 @@ name: build-and-deploy
 
 on:
   push:
-    # TEMP: feat/ci-cd-pipeline included to verify GHCR push works.
-    # Revert to [main] before merging.
-    branches: [main, feat/ci-cd-pipeline]
+    branches: [main]
   pull_request:
   workflow_dispatch:
 
@@ -45,8 +43,7 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - name: Log in to GHCR
-        # TEMP: feat/ci-cd-pipeline included to verify GHCR push works.
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feat/ci-cd-pipeline')
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
@@ -67,8 +64,7 @@ jobs:
         with:
           context: .
           file: api/Dockerfile
-          # TEMP: feat/ci-cd-pipeline included to verify GHCR push works.
-          push: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feat/ci-cd-pipeline') }}
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: ${{ steps.api-meta.outputs.tags }}
           labels: ${{ steps.api-meta.outputs.labels }}
           cache-from: type=gha
@@ -88,8 +84,7 @@ jobs:
         with:
           context: .
           file: Dockerfile.jekyll
-          # TEMP: feat/ci-cd-pipeline included to verify GHCR push works.
-          push: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feat/ci-cd-pipeline') }}
+          push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           tags: ${{ steps.blog-meta.outputs.tags }}
           labels: ${{ steps.blog-meta.outputs.labels }}
           cache-from: type=gha

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,96 @@
+name: build-and-deploy
+
+on:
+  push:
+    # TEMP: feat/ci-cd-pipeline included to verify GHCR push works.
+    # Revert to [main] before merging.
+    branches: [main, feat/ci-cd-pipeline]
+  pull_request:
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  API_IMAGE: ${{ github.repository_owner }}/paperpulse-api
+  BLOG_IMAGE: ${{ github.repository_owner }}/paperpulse-blog
+
+jobs:
+  test:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: api/requirements.txt
+
+      - name: Install deps
+        run: |
+          pip install -r api/requirements.txt
+          pip install pytest
+
+      - name: Run tests
+        run: PYTHONPATH=. pytest api/tests/test_main.py -v
+
+  build:
+    needs: test
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        # TEMP: feat/ci-cd-pipeline included to verify GHCR push works.
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feat/ci-cd-pipeline')
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: API image metadata
+        id: api-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.API_IMAGE }}
+          tags: |
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push API image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: api/Dockerfile
+          # TEMP: feat/ci-cd-pipeline included to verify GHCR push works.
+          push: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feat/ci-cd-pipeline') }}
+          tags: ${{ steps.api-meta.outputs.tags }}
+          labels: ${{ steps.api-meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Blog image metadata
+        id: blog-meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.BLOG_IMAGE }}
+          tags: |
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Blog image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.jekyll
+          # TEMP: feat/ci-cd-pipeline included to verify GHCR push works.
+          push: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feat/ci-cd-pipeline') }}
+          tags: ${{ steps.blog-meta.outputs.tags }}
+          labels: ${{ steps.blog-meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.API_IMAGE }}
           tags: |
-            type=sha,format=long
+            type=sha,format=long,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push API image
@@ -76,7 +76,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.BLOG_IMAGE }}
           tags: |
-            type=sha,format=long
+            type=sha,format=long,prefix=
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Blog image
@@ -89,3 +89,29 @@ jobs:
           labels: ${{ steps.blog-meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    environment: production
+    steps:
+      - name: Set up SSH
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          printf '%s\n' "${{ secrets.DROPLET_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          chmod 644 ~/.ssh/known_hosts
+
+      - name: Trigger deploy on droplet
+        run: |
+          ssh -i ~/.ssh/id_ed25519 \
+              -o IdentitiesOnly=yes \
+              "deploy@${{ secrets.DROPLET_HOST }}" \
+              "${{ github.sha }}"
+
+      - name: Remove SSH private key
+        if: always()
+        run: rm -f ~/.ssh/id_ed25519

--- a/CICD_PLAN.md
+++ b/CICD_PLAN.md
@@ -1,0 +1,87 @@
+# CI/CD Implementation Plan
+
+## Goal
+Replace manual SSH-and-pull deploys with a push-to-main → auto-deploy pipeline. Remove `.env` files from the droplet. Reduce blast radius if GitHub Actions or the droplet is compromised.
+
+## Target architecture
+
+```
+GitHub Actions
+   |
+   | build + test + push Docker images
+   v
+GHCR (GitHub Container Registry)
+   |
+   | SSH as deploy user, restricted to one deploy command
+   v
+Droplet (/var/www/arxivsum)
+   |
+   | docker compose pull
+   | docker compose up -d
+   v
+nginx -> Jekyll container
+      -> API container (with scheduled daily job inside)
+```
+
+## Secrets model
+- App runtime secrets live in `/var/lib/paperpulse/secrets/` on droplet, root-owned, `chmod 600`
+- Referenced via Docker Compose secrets, mounted at `/run/secrets/<name>` inside containers
+- App reads from `/run/secrets/<name>` first, falls back to `os.getenv()` for local dev / forks
+- GitHub Actions only holds infrastructure secrets: `DEPLOY_SSH_PRIVATE_KEY`, `DROPLET_HOST`
+
+## Implementation steps
+
+### 1. Containerize the API
+- Finish `api/Dockerfile` (current one is half-baked, references Flask but `main.py` is a pipeline script)
+- Add `api` service to `docker-compose.prod.yml`
+- Code change: read secrets from `/run/secrets/<name>` first, fall back to `os.getenv()`
+- Keep `load_dotenv()` for local dev compatibility
+
+### 2. CI builds and pushes images
+- GitHub Actions workflow on push to `main`:
+  - Run tests
+  - Build `paperpulse-api` and `paperpulse-blog` images
+  - Tag with git SHA
+  - Push to GHCR
+
+### 3. Server-side secret files
+- One-time setup: `scp` secret files to `/var/lib/paperpulse/secrets/`
+- Reference in `docker-compose.prod.yml` as Docker Compose secrets
+- Update `.dockerignore` to ensure no secret/log files leak into images:
+  - `blog/_site/`
+  - `blog/.jekyll-cache/`
+  - `*.log`
+  - `*.pkl`
+
+### 4. Deploy script on droplet
+- `/usr/local/sbin/deploy-paperpulse <image_tag>`
+- Pulls images, runs `docker compose up -d --remove-orphans`
+- Prunes old images
+- Optionally triggers one-shot run of API pipeline if `api/` changed (smart deploy)
+
+### 5. Deploy user
+- Create `deploy` user on droplet
+- SSH `authorized_keys` restricted via `command="..."` to the deploy script only
+- Sudoers grants NOPASSWD only for `/usr/local/sbin/deploy-paperpulse`
+- Add SSH public key to droplet, private key to GitHub Actions secrets
+
+### 6. Replace cron with systemd timer invoking one-shot container
+- systemd unit `paperpulse-daily.service` runs `docker compose -f /var/www/arxivsum/docker-compose.prod.yml run --rm api python -m api.main`
+- systemd timer `paperpulse-daily.timer` schedules it daily
+- `Persistent=true` catches up missed runs after downtime
+- Logs via `journalctl -u paperpulse-daily`
+- Secrets come via Docker Compose secrets at container start — host has zero secrets
+- Remove crontab entry on droplet
+
+### 7. Cleanup
+- Remove `.env` files from droplet
+- Rotate Gemini API key and Mixpanel token (assume any past `.env` value is compromised)
+- Set Gemini spend cap as defense-in-depth
+- `git rm --cached api/.env blog/.env` if tracked; verify `.gitignore` covers `.env` files
+
+## Out of scope (for now)
+- External secrets manager (Vault, Doppler) — overkill at single-droplet scale
+- Multi-droplet / staging environments
+
+## Open questions to resolve during implementation
+- For step 2: public or private GHCR images? (repo is public, so either works)

--- a/DROPLET_SETUP.md
+++ b/DROPLET_SETUP.md
@@ -1,0 +1,148 @@
+# Droplet setup for automated CI deploys
+
+One-time setup to wire the GitHub Actions `deploy` job into the droplet. Do this after the CI/CD PR has merged to `main` (so the deploy script exists at `scripts/deploy-paperpulse.sh` on the droplet).
+
+All commands run as **root** on the droplet unless otherwise noted.
+
+## 1. Create the `deploy` user
+
+```bash
+# Create user with no password, no shell warmth, no home extras
+useradd --create-home --shell /bin/bash --comment "CI deploy" deploy
+
+# Lock the password — only key-based SSH allowed
+passwd -l deploy
+
+# Set up .ssh dir
+install -d -m 700 -o deploy -g deploy /home/deploy/.ssh
+```
+
+The `deploy` user has a shell (needed so `command="..."` in `authorized_keys` can execute), but the locked password and forced-command restriction below mean it can only run the deploy script — no interactive sessions.
+
+## 2. Generate the SSH keypair
+
+**On your laptop**, generate a dedicated keypair just for CI:
+
+```bash
+ssh-keygen -t ed25519 -f ~/.ssh/paperpulse-deploy -C "paperpulse-ci-deploy" -N ""
+```
+
+Two files appear:
+- `~/.ssh/paperpulse-deploy` — private key (goes into GitHub Actions secret)
+- `~/.ssh/paperpulse-deploy.pub` — public key (goes onto droplet)
+
+## 3. Install the public key with command-restriction
+
+Copy the contents of `~/.ssh/paperpulse-deploy.pub` (a single line starting with `ssh-ed25519 …`). Then on droplet:
+
+```bash
+# Edit /home/deploy/.ssh/authorized_keys
+cat > /home/deploy/.ssh/authorized_keys <<'EOF'
+command="sudo --preserve-env=SSH_ORIGINAL_COMMAND /usr/local/sbin/deploy-paperpulse",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty <PASTE_PUBLIC_KEY_HERE>
+EOF
+
+# Replace <PASTE_PUBLIC_KEY_HERE> with the actual line from ~/.ssh/paperpulse-deploy.pub
+nano /home/deploy/.ssh/authorized_keys   # or your editor
+
+# Perms
+chown deploy:deploy /home/deploy/.ssh/authorized_keys
+chmod 600 /home/deploy/.ssh/authorized_keys
+```
+
+What this does:
+- Every SSH login as `deploy` is forced through `sudo … /usr/local/sbin/deploy-paperpulse`, regardless of what the client tries to run
+- The argument the client sent (the git SHA) lands in `$SSH_ORIGINAL_COMMAND`
+- `sudo --preserve-env=SSH_ORIGINAL_COMMAND` carries that env var into the privileged execution
+- `no-pty`, `no-*-forwarding` disable shell access, port forwarding, X11, agent forwarding
+
+## 4. Sudoers fragment
+
+```bash
+cat > /etc/sudoers.d/deploy-paperpulse <<'EOF'
+# Allow the deploy user to run exactly one root-owned script, with SSH_ORIGINAL_COMMAND preserved.
+deploy ALL=(root) NOPASSWD: SETENV: /usr/local/sbin/deploy-paperpulse
+EOF
+
+chmod 440 /etc/sudoers.d/deploy-paperpulse
+
+# Validate the new fragment doesn't break sudo
+visudo -cf /etc/sudoers.d/deploy-paperpulse
+# Expected: "/etc/sudoers.d/deploy-paperpulse: parsed OK"
+```
+
+## 5. Install the deploy script
+
+```bash
+cd /var/www/arxivsum
+git fetch origin main
+git reset --hard origin/main
+
+install -m 755 -o root -g root scripts/deploy-paperpulse.sh /usr/local/sbin/deploy-paperpulse
+
+# Verify
+ls -la /usr/local/sbin/deploy-paperpulse
+# Expected: -rwxr-xr-x 1 root root <size> <date> /usr/local/sbin/deploy-paperpulse
+```
+
+## 6. Capture ssh-keyscan output for GitHub Actions
+
+**On your laptop:**
+
+```bash
+ssh-keyscan -t ed25519 <DROPLET_IP>
+```
+
+Copy the entire output (a single line starting with the IP, then `ssh-ed25519`, then the host key). You'll paste this into the `DROPLET_KNOWN_HOSTS` secret.
+
+## 7. Configure GitHub Actions secrets
+
+In GitHub → Settings → Secrets and variables → Actions → New repository secret, add three:
+
+- **`DEPLOY_SSH_PRIVATE_KEY`** — entire contents of `~/.ssh/paperpulse-deploy` (the private key file). Include the `-----BEGIN OPENSSH PRIVATE KEY-----` / `-----END OPENSSH PRIVATE KEY-----` lines.
+- **`DROPLET_HOST`** — your droplet's IP address.
+- **`DROPLET_KNOWN_HOSTS`** — the line(s) from `ssh-keyscan` in step 6.
+
+## 8. Create the `production` GitHub Environment
+
+GitHub → Settings → Environments → New environment → name it `production`.
+
+Recommended protection rules:
+- **Required reviewers** — add yourself. Each deploy will pause for your approval in the GH UI before running.
+- **Deployment branches** — restrict to `main` only.
+
+Without protection rules, deploys run automatically on every push to `main`.
+
+## 9. Smoke test
+
+The cleanest test: open a tiny PR on `main` that changes one harmless file (e.g., a comment in README), merge it, watch:
+
+1. The `test` job runs (~30s)
+2. The `build` job runs and pushes images to GHCR (~2 min)
+3. The `deploy` job pauses for approval (if you configured protection rules). Approve it.
+4. The `deploy` job SSHes into the droplet and runs the deploy script
+5. The deploy script git-resets the droplet to the merge commit's SHA, pulls images, recreates containers
+
+Verify on droplet after deploy:
+
+```bash
+docker compose -f /var/www/arxivsum/docker-compose.prod.yml ps
+# All services should show "Up"
+
+cd /var/www/arxivsum && git rev-parse HEAD
+# Should match the merge commit SHA
+```
+
+If anything goes sideways, see `ROLLBACK.md`.
+
+## Manual deploy (no SSH path)
+
+You can also invoke the deploy script directly on the droplet:
+
+```bash
+sudo /usr/local/sbin/deploy-paperpulse <40-char-git-sha>
+
+# Or with optional pipeline trigger
+sudo /usr/local/sbin/deploy-paperpulse <40-char-git-sha> --run-pipeline
+```
+
+CI never passes `--run-pipeline`. Daily pipeline runs via the systemd timer (step 6 of the CI/CD plan).

--- a/ROLLBACK.md
+++ b/ROLLBACK.md
@@ -1,0 +1,102 @@
+# Rollback procedures
+
+How to revert a bad deploy of the ArXivSum / PaperPulse stack on the droplet.
+
+## Standard rollback (after at least one successful deploy)
+
+Every successful CI run on `main` pushes images to GHCR tagged with that commit's full SHA. Those tags are immutable — they never get overwritten. Rolling back means redeploying with an older SHA.
+
+```bash
+# 1. Find the SHA you want to roll back to. Either:
+#    (a) Look at git log on the droplet
+cd /var/www/arxivsum && git log --oneline -10
+
+#    (b) Look at the GitHub Actions history — every successful run shows its SHA
+#        https://github.com/unmeshk/paperpulse/actions
+
+# 2. Verify both images exist for that SHA before deploying
+docker pull ghcr.io/unmeshk/paperpulse-api:<old_sha>
+docker pull ghcr.io/unmeshk/paperpulse-blog:<old_sha>
+
+# 3. Roll back — re-run the deploy script with the older tag
+/usr/local/sbin/deploy-paperpulse <old_sha>
+```
+
+The script will `git reset --hard` to the old SHA (so the compose file + blog content match the images), pull the old images, and restart containers.
+
+Time to roll back: ~30 seconds.
+
+## Knowing what's currently deployed
+
+```bash
+# Image tag currently running
+docker inspect $(docker compose -f /var/www/arxivsum/docker-compose.prod.yml ps -q api) \
+  --format '{{.Config.Image}}'
+
+# Or check git on the droplet (the deploy script pins HEAD via git reset --hard)
+cd /var/www/arxivsum && git rev-parse HEAD
+```
+
+## First-deploy rollback (special case)
+
+After the initial PR merges from `feat/ci-cd-pipeline`, there is no previous "image-based" version to roll back to. The pre-CI world ran the API via venv + cron, built the blog image locally, and had no `image:` references in the compose file.
+
+### Option 1 — forward fix (preferred)
+
+1. Revert the breaking commit on `main` via the GitHub UI ("Revert" button on the merge commit), then merge that revert PR.
+2. CI builds new images for the revert commit.
+3. Re-run the deploy script on the droplet with the new SHA.
+
+Total time: ~5 minutes (mostly waiting for CI). Cleanest.
+
+### Option 2 — manual restore to pre-CI state
+
+Only use if a forward fix isn't viable.
+
+```bash
+cd /var/www/arxivsum
+
+# Stop the new containers
+docker compose -f docker-compose.prod.yml down
+
+# Reset to the merge commit's parent (pre-CI compose file)
+git reset --hard <pre-pr-merge-sha>
+
+# Restore old .env files if you'd deleted them
+# (Have them somewhere safe in advance — they're gone from the droplet otherwise.)
+
+# Rebuild old way (this rebuilds locally, not from images)
+docker compose -f docker-compose.prod.yml up -d --build
+
+# Verify
+docker compose -f docker-compose.prod.yml ps
+```
+
+## Dry-run test rollback (pre-merge)
+
+If you used the dry-run procedure to test the new compose file + script before merging to main, and something went wrong:
+
+```bash
+cd /var/www/arxivsum
+
+# Restore the original compose file from the backup made during dry-run
+mv docker-compose.prod.yml.bak docker-compose.prod.yml
+
+# Tear down everything and rebuild with old setup
+docker compose -f docker-compose.prod.yml down
+docker compose -f docker-compose.prod.yml up -d --build
+
+# Verify
+docker compose -f docker-compose.prod.yml ps
+```
+
+The droplet still has the original code on disk (no `git reset --hard` runs during dry-run), so `--build` will rebuild from local source the same way it did before. Should fully restore the pre-test state.
+
+## Mitigations to reduce first-deploy risk
+
+Before merging the CI/CD PR to `main`:
+
+1. Pull the soon-to-be-`latest` images locally and run them with `docker-compose.prod.yml` (using a stub secrets dir).
+2. Run the dry-run procedure on the droplet using one of the feature-branch SHA-tagged images (if they're still in GHCR).
+3. Confirm `/var/lib/paperpulse/secrets/gemini_api_key` exists and is readable by root.
+4. Plan the merge for a time when you can immediately respond if something breaks.

--- a/WORKLOG.md
+++ b/WORKLOG.md
@@ -1,6 +1,62 @@
 # Worklog
 
-## Session: 2026-06-03 (continued)
+## Session: 2026-06-03 → 2026-06-06 (CI/CD pipeline + OS upgrade)
+
+### Worked on
+Setting up automated CI/CD for ArXivSum: push-to-main → CI builds → deploy to droplet. Branch: `feat/ci-cd-pipeline`.
+
+### Completed
+
+**Step 1: containerize the API** (commit `6e7847d`)
+- Added `get_secret()` helper in `api/settings.py` that reads `/run/secrets/<name>` first, falls back to `os.getenv()` for local dev
+- Switched `main.py` to use it for `GEMINI_API_KEY`
+- Rewrote `api/Dockerfile` (was a half-baked Flask template) — Python 3.11, `python -m api.main` entrypoint
+- Added `api` service to `docker-compose.prod.yml` with Docker Compose secrets binding from `/var/lib/paperpulse/secrets/gemini_api_key`
+- Dropped unused deps from `requirements.txt`: Flask, Flask-SQLAlchemy, gunicorn, psycopg2-binary
+- Commented out unused PDF processing imports in `main.py` and `utils.py` with TODO markers
+- 3 new pytest tests for `get_secret()`
+
+**Step 2: CI builds and pushes images to GHCR** (commits `3162bf8`, `cc48127`, `25cd4fb`)
+- New workflow `.github/workflows/deploy.yml` — runs tests, builds both images with git SHA + `latest` tags, pushes to GHCR
+- Pushes only on `main`; PRs and `workflow_dispatch` run test+build without pushing
+- Fixed pre-existing `test_create_blogpost` that depended on `PROJECT_DIR` being set in env
+- Verified end-to-end: temporarily added feat branch to push triggers, watched workflow succeed, both images appeared in GHCR, reverted temp triggers
+
+**Step 3: server-side secrets**
+- `/var/lib/paperpulse/secrets/gemini_api_key` installed on droplet, root-owned, `chmod 600`
+- Directory `chmod 700`
+- (User ran this manually following the runbook)
+
+**Step 4: deploy script + ROLLBACK.md** (commit `57afc80`)
+- Switched `docker-compose.prod.yml` to `image:` references (no more `build:` in prod)
+- `scripts/deploy-paperpulse.sh` — takes git SHA, does `git reset --hard origin/main`, pulls images, recreates containers, prunes layers, optionally runs pipeline one-shot
+- `ROLLBACK.md` — procedures for image-tag rollback, first-deploy special case, dry-run rollback
+
+**Unplanned: OS upgrade**
+- Discovered droplet was on Ubuntu 24.10 (EOL since July 2025); apt repos were 404'ing
+- Upgraded in place 24.10 → 25.10 via `do-release-upgrade` (after pointing sources to `old-releases.ubuntu.com`)
+- Survived an SSH connection drop mid-upgrade (the upgrade tool's screen session kept going)
+- Installed Docker Compose V2 plugin via Docker's official apt repo
+- Brought old stack back up; production is back online on the upgraded OS
+
+### Decisions made
+- App secrets via Docker Compose file-based secrets (host file mounted at `/run/secrets/<name>`), not Swarm secrets. Cheap to migrate later if needed; no code changes required.
+- Deploy script does `git fetch + git reset --hard origin/main`, not `git pull`. Deterministic. Untracked files (daily generated posts) survive.
+- `MIXPANEL_TOKEN` deferred — still set via `${MIXPANEL_TOKEN}` env var, not Compose secrets. Low-stakes since it's client-side anyway.
+- Dry-run test before merging was attempted but didn't complete due to OS upgrade priority shift. Skipping in favor of post-merge testing with rollback procedures in place.
+- 25.10 is not LTS (EOL ~July 2026). Plan a fresh-droplet migration to 24.04 LTS as a separate session.
+
+### Next session priorities
+- Step 5: create restricted `deploy` user on droplet, wire SSH keys into GitHub Actions
+- Step 6: replace cron with systemd timer that invokes `docker compose run --rm api`
+- Step 7: cleanup — rotate Gemini and Mixpanel keys (assume old `.env` values are compromised), remove old `.env` files from droplet, set Gemini spend cap
+- Set up branch protection on `main` (require PR + status checks)
+- Delete the feature-branch SHA-tagged test images from GHCR
+- Plan migration from 25.10 to a fresh 24.04 LTS droplet (separate session)
+
+---
+
+## Session: 2026-06-03 (continued — part 2)
 
 ### Worked on
 Cleanup, dependency hygiene, and content fixes after the RSS/Gemini migration.
@@ -31,7 +87,6 @@ Cleanup, dependency hygiene, and content fixes after the RSS/Gemini migration.
 - `summarize_paper` commented out rather than deleted — preserves the OpenAI RAG approach for potential future use with a different LLM
 
 ### Next session priorities
-- Merge `refactor/oai-pmh-migration` → `main` to close all 4 Dependabot alerts
 - Delete `summarize_paper` and related OpenAI methods fully (TODO already in code)
 - Set up cron job in prod Docker config to run the pipeline daily
 - Investigate whether `MIXPANEL_TOKEN` tracking is wired up correctly for the new blog post format

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,10 +1,10 @@
-FROM python:3.9-slim
+FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY requirements.txt .
-RUN pip install -r requirements.txt
+COPY api/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+COPY api/ ./api/
 
-CMD ["flask", "run", "--host=0.0.0.0"]
+CMD ["python", "-m", "api.main"]

--- a/api/main.py
+++ b/api/main.py
@@ -10,15 +10,17 @@ from datetime import datetime
 import xml.etree.ElementTree as ET
 
 from dotenv import load_dotenv
-from api.utils import (
-    extract_text_from_pdf,
-    extract_images_from_pdf_base64,
-    download_pdf,
-)
+# TODO: remove these imports — they pull in pdfplumber/Pillow but the functions are not used by main().
+# Kept commented as a marker until we decide whether to bring back PDF processing or delete utils.py outright.
+# from api.utils import (
+#     extract_text_from_pdf,
+#     extract_images_from_pdf_base64,
+#     download_pdf,
+# )
 from api.arxiv_client import ArxivClient
 from api.agent import Agent
 from api.file_handler import FileHandler
-from api.settings import RSS_CATEGORIES
+from api.settings import RSS_CATEGORIES, get_secret
 
 from api.webs import create_blogpost
 
@@ -38,7 +40,7 @@ def main():
 
     # initalize
     arxiv_client = ArxivClient(RSS_CATEGORIES)
-    llm_agent = Agent(os.getenv("GEMINI_API_KEY"))
+    llm_agent = Agent(get_secret("gemini_api_key"))
     file_handler = FileHandler(os.getenv("PROJECT_DIR"))
     papers = None
 

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,7 +1,3 @@
-Flask==3.1.3
-Flask-SQLAlchemy==3.1.1
 python-dotenv==1.2.2
-gunicorn==23.0.0
-psycopg2-binary==2.9.9
 google-genai==2.7.0
 PyMuPDF==1.27.2.3

--- a/api/settings.py
+++ b/api/settings.py
@@ -1,3 +1,18 @@
+import os
+from pathlib import Path
+
+
+def get_secret(name):
+    """Read a secret from /run/secrets/<name> if present, else fall back to os.getenv(NAME.upper()).
+
+    Lets prod use Docker Compose secrets while local dev keeps reading from .env via os.getenv.
+    """
+    secret_path = Path("/run/secrets") / name
+    if secret_path.exists():
+        return secret_path.read_text().strip()
+    return os.getenv(name.upper())
+
+
 SUMMARY_PROMPT = """
 You are a research scientist and professor with a PhD in machine learning. 
 You are also an educator skilled in explaining complex scientific concepts to the average technology professional. 

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -13,6 +13,7 @@ from api.agent import Agent
 from api.file_handler import FileHandler
 from api.utils import add_markdown_links, download_pdf
 from api.webs import create_blogpost
+from api.settings import get_secret
 
 
 # Fixtures
@@ -212,6 +213,37 @@ def test_create_blogpost(mock_open):
     # Check YAML front matter format
     assert written_content.startswith("---\n")
     assert "---\n" in written_content[3:]  # Check for closing front matter delimiter
+
+
+# get_secret tests
+class TestGetSecret:
+    @pytest.fixture
+    def patch_secrets_dir(self, tmp_path, monkeypatch):
+        """Redirect the /run/secrets lookup in api.settings to a tmp dir."""
+        import api.settings as settings_mod
+        original_path = settings_mod.Path
+        secrets_dir = tmp_path / "secrets"
+        secrets_dir.mkdir()
+
+        def fake_path(arg):
+            if arg == "/run/secrets":
+                return secrets_dir
+            return original_path(arg)
+
+        monkeypatch.setattr(settings_mod, "Path", fake_path)
+        return secrets_dir
+
+    def test_reads_from_secrets_file_when_present(self, patch_secrets_dir):
+        (patch_secrets_dir / "my_key").write_text("secret-from-file\n")
+        assert get_secret("my_key") == "secret-from-file"
+
+    def test_falls_back_to_env_when_file_absent(self, patch_secrets_dir, monkeypatch):
+        monkeypatch.setenv("MY_KEY", "secret-from-env")
+        assert get_secret("my_key") == "secret-from-env"
+
+    def test_returns_none_when_neither_present(self, patch_secrets_dir, monkeypatch):
+        monkeypatch.delenv("MISSING_KEY", raising=False)
+        assert get_secret("missing_key") is None
 
 
 if __name__ == '__main__':

--- a/api/tests/test_main.py
+++ b/api/tests/test_main.py
@@ -191,10 +191,11 @@ def test_download_pdf(mock_urlopen):
 
 # Tests for create_blogpost
 @patch('builtins.open', create=True)
-def test_create_blogpost(mock_open):
+def test_create_blogpost(mock_open, monkeypatch):
+    monkeypatch.setenv('PROJECT_DIR', '/tmp')
     summary = "Test summary content"
     num_papers = 5
-    
+
     create_blogpost(summary, num_papers)
     
     mock_open.assert_called_once()

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,10 +1,15 @@
-import pdfplumber
+# TODO: pdfplumber, PIL, and fitz are only used by extract_text_from_pdf and
+# extract_images_from_pdf_base64, which are no longer called by main().
+# Imports commented out so prod and dev requirements stay aligned. Restore
+# (and re-add to requirements.txt) if PDF processing comes back, or delete
+# the unused functions entirely.
+# import pdfplumber
+# import fitz  # PyMuPDF
+# from PIL import Image
 import io
 import base64
-import fitz  # PyMuPDF
 import urllib
 import os
-from PIL import Image
 import urllib.request as libreq
 
 def extract_text_from_pdf(pdf_content):

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,8 +1,6 @@
 services:
   blog:
-    build:
-      context: .
-      dockerfile: Dockerfile.jekyll
+    image: ghcr.io/unmeshk/paperpulse-blog:${IMAGE_TAG:-latest}
     expose:
       - "4000"
     volumes:
@@ -14,9 +12,7 @@ services:
       - web
 
   api:
-    build:
-      context: .
-      dockerfile: api/Dockerfile
+    image: ghcr.io/unmeshk/paperpulse-api:${IMAGE_TAG:-latest}
     volumes:
       - ./blog:/app/blog
     environment:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -13,6 +13,20 @@ services:
     networks:
       - web
 
+  api:
+    build:
+      context: .
+      dockerfile: api/Dockerfile
+    volumes:
+      - ./blog:/app/blog
+    environment:
+      PROJECT_ENV: prod
+      PROJECT_DIR: /app
+    secrets:
+      - gemini_api_key
+    networks:
+      - web
+
   nginx:
     image: nginx:alpine
     ports:
@@ -39,3 +53,7 @@ services:
 networks:
   web:
     driver: bridge
+
+secrets:
+  gemini_api_key:
+    file: /var/lib/paperpulse/secrets/gemini_api_key

--- a/scripts/deploy-paperpulse.sh
+++ b/scripts/deploy-paperpulse.sh
@@ -1,17 +1,33 @@
 #!/usr/bin/env bash
 # Deploy script for ArXivSum / PaperPulse.
-# Installed at /usr/local/sbin/deploy-paperpulse on the droplet.
-# Invoked by CI over SSH as the `deploy` user via sudo (NOPASSWD restricted to this script).
+# Installed at /usr/local/sbin/deploy-paperpulse on the droplet, root-owned.
+# Invoked via sudo (NOPASSWD restricted to this script for the `deploy` user).
 #
-# Usage: deploy-paperpulse <image_tag> [--run-pipeline]
-#   image_tag       Full git SHA tag pushed to GHCR (e.g. abc123def...)
-#   --run-pipeline  Optional: after pulling images, run main.py once
-#                   (used when the CI workflow detects changes under api/)
+# Two invocation paths:
+#   1. CI over SSH. The `deploy` user's authorized_keys forces a single
+#      command="sudo --preserve-env=SSH_ORIGINAL_COMMAND /usr/local/sbin/deploy-paperpulse".
+#      The git SHA arrives in $SSH_ORIGINAL_COMMAND.
+#   2. Manual on droplet: sudo /usr/local/sbin/deploy-paperpulse <git_sha> [--run-pipeline]
+#
+# Input is validated strictly (40-char hex SHA). Defense in depth on top of the
+# sudoers + authorized_keys restrictions.
 
 set -euo pipefail
 
-IMAGE_TAG="${1:?image tag required (full git SHA)}"
+# Read tag from $1 (manual) or $SSH_ORIGINAL_COMMAND (SSH-forced-command).
+IMAGE_TAG="${1:-${SSH_ORIGINAL_COMMAND:-}}"
 RUN_PIPELINE="${2:-}"
+
+if [ -z "$IMAGE_TAG" ]; then
+    echo "Usage: deploy-paperpulse <git_sha> [--run-pipeline]" >&2
+    exit 1
+fi
+
+# Strict input validation. Reject anything that isn't a 40-char hex git SHA.
+if ! [[ "$IMAGE_TAG" =~ ^[a-f0-9]{40}$ ]]; then
+    echo "Refusing to deploy: image tag must be a 40-char git SHA, got: $IMAGE_TAG" >&2
+    exit 1
+fi
 
 REPO_DIR="/var/www/arxivsum"
 COMPOSE_FILE="${REPO_DIR}/docker-compose.prod.yml"

--- a/scripts/deploy-paperpulse.sh
+++ b/scripts/deploy-paperpulse.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# Deploy script for ArXivSum / PaperPulse.
+# Installed at /usr/local/sbin/deploy-paperpulse on the droplet.
+# Invoked by CI over SSH as the `deploy` user via sudo (NOPASSWD restricted to this script).
+#
+# Usage: deploy-paperpulse <image_tag> [--run-pipeline]
+#   image_tag       Full git SHA tag pushed to GHCR (e.g. abc123def...)
+#   --run-pipeline  Optional: after pulling images, run main.py once
+#                   (used when the CI workflow detects changes under api/)
+
+set -euo pipefail
+
+IMAGE_TAG="${1:?image tag required (full git SHA)}"
+RUN_PIPELINE="${2:-}"
+
+REPO_DIR="/var/www/arxivsum"
+COMPOSE_FILE="${REPO_DIR}/docker-compose.prod.yml"
+
+cd "$REPO_DIR"
+
+# Refresh blog content + compose file from main.
+# Images carry the code; this only refreshes host-mounted assets and the
+# compose file itself (so layouts, _config.yml, nginx.conf etc. stay in sync
+# with whatever the new images expect).
+git fetch origin main
+git reset --hard origin/main
+
+export IMAGE_TAG
+
+# Pull new images from GHCR.
+docker compose -f "$COMPOSE_FILE" pull
+
+# Recreate containers with the new images. --remove-orphans cleans up any
+# services that have been removed from the compose file.
+docker compose -f "$COMPOSE_FILE" up -d --remove-orphans
+
+# Optionally run the daily pipeline once (CI sets this when api/ changed).
+if [ "$RUN_PIPELINE" = "--run-pipeline" ]; then
+    docker compose -f "$COMPOSE_FILE" run --rm api python -m api.main
+fi
+
+# Clean up dangling image layers from previous deploys.
+docker image prune -f


### PR DESCRIPTION
---
  Title: Automated CI/CD: build images in GH Actions, deploy via SSH to droplet

  Body:

  ## Summary
  Replaces the manual SSH-and-pull deploy with a push-to-main → CI build → SSH deploy
  pipeline.

  - **Test + build + push** images to GHCR on every push to main (tests + builds on PRs
  too, no push)
  - **Deploy job** SSHes into the droplet as a restricted `deploy` user and runs
  `/usr/local/sbin/deploy-paperpulse <git_sha>`. Gated by the `production` environment,
  allowing manual approval before each deploy
  - **Containerized API**: new `api` service in `docker-compose.prod.yml`, reads
  `GEMINI_API_KEY` from a Docker Compose secret mounted at `/run/secrets/gemini_api_key`
  (file on droplet at `/var/lib/paperpulse/secrets/`)
  - **Deploy script** with strict input validation (40-char hex SHA), refuses anything
  else
  - **Sudoers + authorized_keys** restrict the `deploy` user to running exactly one
  root-owned script with a forced command — no shell, no port forwarding, no agent
  ## Test plan
  - [x] Local: pytest passes (14 tests, 3 new for `get_secret`)
  - [x] Local: API image builds, container imports + reads mounted secret correctly
  - [x] Local: blog image builds
  - [x] Local: compose syntax validates
  - [x] CI: GHCR push verified end-to-end (temp trigger, now reverted)
  - [x] Droplet: secret installed, `deploy` user + authorized_keys + sudoers all set up
  and validated
  - [x] Droplet: manual SSH test from laptop reached deploy script, validation passed, git
   fetch + reset worked
  - [x] Droplet: bad-input rejection confirmed
  - [ ] First auto-deploy after merge: approve in `production` environment, watch full
  chain, verify site stays up
  - [ ] Rollback verification: test redeploying with older SHA

  ## Out of scope (follow-ups)
  - Step 6: replace daily cron with systemd timer
  - Step 7: rotate keys, remove old `.env` files, set Gemini spend cap
  - OS migration from 25.10 to 24.04 LTS
  - Delete leftover feature-branch test images from GHCR

  ## Documentation
  - `CICD_PLAN.md` — overall design
  - `DROPLET_SETUP.md` — droplet-side setup runbook (already executed)
  - `ROLLBACK.md` — rollback procedures