### PR TITLE
Replace daily cron with systemd timer for the pipeline

### DIFF
--- a/DROPLET_SETUP.md
+++ b/DROPLET_SETUP.md
@@ -145,4 +145,78 @@ sudo /usr/local/sbin/deploy-paperpulse <40-char-git-sha>
 sudo /usr/local/sbin/deploy-paperpulse <40-char-git-sha> --run-pipeline
 ```
 
-CI never passes `--run-pipeline`. Daily pipeline runs via the systemd timer (step 6 of the CI/CD plan).
+CI never passes `--run-pipeline`. Daily pipeline runs via the systemd timer (see below).
+
+## 10. Install the systemd timer for the daily pipeline
+
+Replaces the old `crontab -e` entry that ran the pipeline via venv.
+
+### Disable the old cron entry first
+
+```bash
+crontab -l
+# Look for the line: 0 7 * * * cd /var/www/arxivsum/api && /var/www/arxivsum/avenv/bin/python ...
+# Remove it (or comment it out by adding a # at the start of the line)
+crontab -e
+```
+
+### Install the unit files
+
+```bash
+cd /var/www/arxivsum
+git fetch origin main
+git reset --hard origin/main
+
+install -m 644 -o root -g root systemd/paperpulse-daily.service /etc/systemd/system/paperpulse-daily.service
+install -m 644 -o root -g root systemd/paperpulse-daily.timer /etc/systemd/system/paperpulse-daily.timer
+
+# Make systemd aware of the new units
+systemctl daemon-reload
+
+# Enable + start the timer (the .service runs on demand)
+systemctl enable --now paperpulse-daily.timer
+```
+
+### Verify
+
+```bash
+# Confirm the timer is loaded and active
+systemctl status paperpulse-daily.timer
+
+# Show next firing time
+systemctl list-timers paperpulse-daily.timer
+# Expect: NEXT column shows tomorrow 06:00:00 Eastern (10:00 UTC during DST)
+```
+
+### Trigger a one-off run to test
+
+```bash
+# Run the service immediately, just once
+systemctl start paperpulse-daily.service
+
+# Watch the logs as it runs
+journalctl -u paperpulse-daily.service -f
+# Ctrl-C to stop tailing (doesn't affect the run)
+
+# After it finishes, confirm a post got generated
+ls -la /var/www/arxivsum/blog/_posts/ | head -5
+```
+
+### Useful inspection commands going forward
+
+```bash
+# Last 50 log lines from a run
+journalctl -u paperpulse-daily.service -n 50
+
+# Logs from a specific date
+journalctl -u paperpulse-daily.service --since "2026-06-06"
+
+# Service status (last invocation result, exit code)
+systemctl status paperpulse-daily.service
+
+# Disable the timer (e.g. for maintenance)
+systemctl disable --now paperpulse-daily.timer
+
+# Re-enable
+systemctl enable --now paperpulse-daily.timer
+```

--- a/systemd/paperpulse-daily.service
+++ b/systemd/paperpulse-daily.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=PaperPulse daily ArXiv summary pipeline
+Documentation=https://github.com/unmeshk/paperpulse
+Wants=docker.service network-online.target
+After=docker.service network-online.target
+Requires=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/var/www/arxivsum
+Environment="PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ExecStart=/usr/bin/docker compose -f /var/www/arxivsum/docker-compose.prod.yml run --rm api python -m api.main
+
+# Gemini batching with 30s sleeps takes ~10min on heavy days; allow plenty of headroom
+TimeoutStartSec=30min
+
+# Capture stdout/stderr into the journal
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/paperpulse-daily.timer
+++ b/systemd/paperpulse-daily.timer
@@ -1,0 +1,18 @@
+[Unit]
+Description=Run PaperPulse daily ArXiv pipeline at 6am Eastern
+Documentation=https://github.com/unmeshk/paperpulse
+
+[Timer]
+# 6am Eastern, year-round (DST handled by zoneinfo)
+OnCalendar=*-*-* 06:00:00 America/New_York
+
+# If the droplet was down at the scheduled time, run on next boot
+Persistent=true
+
+# Small jitter to avoid the exact-minute thundering herd if other services share a schedule
+RandomizedDelaySec=5min
+
+Unit=paperpulse-daily.service
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary
  - Adds `systemd/paperpulse-daily.service` and `.timer` to run the pipeline at 6am
  Eastern via the containerized API
  - DST handled automatically via per-timer `OnCalendar=*-*-* 06:00:00 America/New_York`
  - `Persistent=true` catches up missed runs after droplet downtime
  - Logs via `journalctl -u paperpulse-daily.service` (no more `>> /tmp/cron-errors.txt`)
  - Appends install runbook to `DROPLET_SETUP.md`

  Replaces the old `0 7 * * *` cron line that ran the pipeline via venv — broken since the
   OS upgrade bumped Python 3.12 → 3.13.

  ## Test plan
  - [x] Local: unit files exist, install runbook appended
  - [ ] After merge: run install steps from `DROPLET_SETUP.md` step 10 on droplet
  - [ ] Verify `systemctl list-timers paperpulse-daily.timer` shows next run at 06:00
  Eastern
  - [ ] Trigger a manual one-shot via `systemctl start paperpulse-daily.service` and
  confirm today's post lands in `blog/_posts/`