### PR TITLE
Handle empty arXiv feeds gracefully and surface pipeline logs

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -1,6 +1,7 @@
 import os
 import pickle
 import re
+import sys
 import logging
 
 import urllib
@@ -25,7 +26,17 @@ from api.settings import RSS_CATEGORIES, get_secret
 from api.webs import create_blogpost
 
 logger = logging.getLogger(__name__)
-logging.basicConfig(filename='myapp.log', level=logging.INFO)
+# LOG_DIR lets the container redirect log files to a host-mounted volume so runs
+# survive `docker compose run --rm`. Defaults to CWD for local dev.
+_log_dir = os.getenv("LOG_DIR", ".")
+_log_path = os.path.join(_log_dir, "myapp.log")
+logging.basicConfig(
+    level=logging.INFO,
+    handlers=[
+        logging.FileHandler(_log_path),
+        logging.StreamHandler(sys.stderr),
+    ],
+)
 logger.setLevel(logging.INFO)
 
 
@@ -58,7 +69,9 @@ def main():
                 file_handler.save_papers(papers)
                 
         if not papers:
-            logger.error('No papers retrieved')
+            # Empty feeds are a legitimate steady state (e.g. arXiv didn't publish
+            # in the last cycle). Treat as a no-op success, not an error.
+            logger.info('No papers retrieved; skipping today\'s post')
             return
         
         logger.info(f'Retrieved: {len(papers)} papers')

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -15,9 +15,11 @@ services:
     image: ghcr.io/unmeshk/paperpulse-api:${IMAGE_TAG:-latest}
     volumes:
       - ./blog:/app/blog
+      - ./logs:/app/logs
     environment:
       PROJECT_ENV: prod
       PROJECT_DIR: /app
+      LOG_DIR: /app/logs
     secrets:
       - gemini_api_key
     networks:


### PR DESCRIPTION
The 6am EDT systemd timer fired on Sun 2026-06-07 but produced no post. The pipeline correctly identified an empty cs.LG RSS feed but logged ERROR then exited 0 — invisible from the host because logging was file-only inside the container and the file died with --rm.

- api/main.py: add StreamHandler(stderr) so systemd's journal captures pipeline output. Honor a LOG_DIR env var so the file handler can write to a host-mounted volume that survives --rm.
- api/main.py: downgrade "No papers retrieved" from ERROR to INFO. Empty feeds are a legitimate steady state (arXiv didn't publish in the last cycle), not a failure.
- docker-compose.prod.yml: mount ./logs:/app/logs on the api service and set LOG_DIR=/app/logs.