### PR TITLE
Fix nginx 502 on blog container recreate via runtime DNS resolver

### DIFF
--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -18,11 +18,19 @@ server {
     ssl_certificate /etc/letsencrypt/live/paperpulse.ukurup.com/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/paperpulse.ukurup.com/privkey.pem;
 
+    resolver 127.0.0.11 valid=10s ipv6=off;
+
     location / {
-        proxy_pass http://blog:4000;
+        set $blog_upstream blog:4000;
+        proxy_pass http://$blog_upstream;
+
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_connect_timeout 5s;
+        proxy_read_timeout 60s;
+        proxy_send_timeout 60s;
     }
 }


### PR DESCRIPTION
nginx was resolving the `blog` hostname once at startup and caching the IP forever. When the blog container was recreated (every deploy), it got a new IP and nginx kept proxying to the old, unreachable address, causing 502s site-wide until manual restart.

Switch to variable-based proxy_pass with Docker's embedded DNS resolver (127.0.0.11) so nginx re-resolves at request time. Also add basic proxy timeouts so a dead backend fails fast (5s connect) instead of hanging on defaults.