### PR TITLE
Phase 1 chunk 0: app skeleton + Google OAuth + /goal prep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,7 @@ cython_debug/
 #.idea/
 certbot/
 blog/_posts/*
+docs/internal-readme.md
+app/.env
+app/.venv/
+app/paperpulse.sqlite*

--- a/app/.env.example
+++ b/app/.env.example
@@ -1,0 +1,8 @@
+# Copy to app/.env and fill in real values. Never commit app/.env.
+GOOGLE_OAUTH_CLIENT_ID=
+GOOGLE_OAUTH_CLIENT_SECRET=
+SESSION_SECRET=
+# Optional overrides. Defaults are fine for local dev.
+# DB_PATH=app/paperpulse.sqlite
+# CONTENT_DIR=./content
+# COOKIE_SECURE=false

--- a/app/README.md
+++ b/app/README.md
@@ -1,0 +1,63 @@
+# PaperPulse app (Phase 1 skeleton)
+
+FastAPI + SQLite + Google OAuth. Runs independently of the daily pipeline in `api/`.
+
+## Local setup
+
+```
+cd app
+python -m venv .venv
+.venv/bin/pip install -r requirements.txt
+cp .env.example .env
+# Edit .env: paste GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET, SESSION_SECRET
+```
+
+Generate a session secret:
+
+```
+openssl rand -hex 32
+```
+
+## Run
+
+From the repo root (so `app.*` imports resolve):
+
+```
+PYTHONPATH=. app/.venv/bin/uvicorn app.main:app --reload --port 8000
+```
+
+Open http://localhost:8000 and click "Sign in with Google".
+
+## Files
+
+- `main.py` — FastAPI app factory, session middleware, startup hook
+- `config.py` — loads `app/.env`, exposes typed settings
+- `db.py` — SQLite connection helper (WAL + FK on), schema bootstrap
+- `schema.sql` — users / categories / user_categories / daily_runs
+- `auth.py` — Authlib Google OAuth, login / callback / logout, user upsert
+- `routes.py` — `/` (placeholder), `/healthz`
+- `templates/` — Jinja2 SSR templates
+
+## Test
+
+From the repo root:
+
+```
+PYTHONPATH=. app/.venv/bin/pytest app/tests
+```
+
+Tests use a tmpdir SQLite DB and dummy OAuth env vars (set in `app/tests/conftest.py`).
+No real network calls.
+
+## `/goal` mode
+
+Acceptance criteria for each phase 1 chunk live in `docs/PHASE1_CHUNKS.md`.
+Autonomy boundary for `/goal` runs is in `docs/GOAL_AUTONOMY.md`.
+
+## What this skeleton does NOT do yet
+
+- Category picker
+- Feed page
+- Category seed
+- CSRF on POST endpoints (no POST endpoints yet)
+- Dockerfile / compose entry

--- a/app/auth.py
+++ b/app/auth.py
@@ -1,0 +1,82 @@
+from authlib.integrations.starlette_client import OAuth, OAuthError
+from fastapi import APIRouter, Request
+from fastapi.responses import RedirectResponse
+from starlette.status import HTTP_302_FOUND
+
+from app.config import settings
+from app.db import get_conn
+
+oauth = OAuth()
+oauth.register(
+    name="google",
+    client_id=settings.google_client_id,
+    client_secret=settings.google_client_secret,
+    server_metadata_url="https://accounts.google.com/.well-known/openid-configuration",
+    client_kwargs={"scope": "openid email profile"},
+)
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.get("/login")
+async def login(request: Request):
+    redirect_uri = request.url_for("auth_callback")
+    return await oauth.google.authorize_redirect(request, str(redirect_uri))
+
+
+@router.get("/google/callback", name="auth_callback")
+async def auth_callback(request: Request):
+    try:
+        token = await oauth.google.authorize_access_token(request)
+    except OAuthError as err:
+        return RedirectResponse(url=f"/?auth_error={err.error}", status_code=HTTP_302_FOUND)
+
+    userinfo = token.get("userinfo") or {}
+    google_sub = userinfo.get("sub")
+    email = userinfo.get("email")
+    if not google_sub or not email:
+        return RedirectResponse(url="/?auth_error=missing_claims", status_code=HTTP_302_FOUND)
+
+    display_name = userinfo.get("name")
+    picture_url = userinfo.get("picture")
+
+    user_id = _upsert_user(google_sub, email, display_name, picture_url)
+    request.session["user_id"] = user_id
+    return RedirectResponse(url="/", status_code=HTTP_302_FOUND)
+
+
+@router.get("/logout")
+async def logout(request: Request):
+    request.session.clear()
+    return RedirectResponse(url="/", status_code=HTTP_302_FOUND)
+
+
+def _upsert_user(google_sub: str, email: str, display_name: str | None, picture_url: str | None) -> int:
+    with get_conn() as conn:
+        cur = conn.execute("SELECT id FROM users WHERE google_sub = ?", (google_sub,))
+        row = cur.fetchone()
+        if row:
+            conn.execute(
+                "UPDATE users SET email = ?, display_name = ?, picture_url = ?, "
+                "updated_at = CURRENT_TIMESTAMP, deleted_at = NULL WHERE id = ?",
+                (email, display_name, picture_url, row["id"]),
+            )
+            return int(row["id"])
+        cur = conn.execute(
+            "INSERT INTO users (google_sub, email, display_name, picture_url) VALUES (?, ?, ?, ?)",
+            (google_sub, email, display_name, picture_url),
+        )
+        return int(cur.lastrowid)
+
+
+def current_user(request: Request) -> dict | None:
+    user_id = request.session.get("user_id")
+    if not user_id:
+        return None
+    with get_conn() as conn:
+        cur = conn.execute(
+            "SELECT id, email, display_name, picture_url FROM users WHERE id = ? AND deleted_at IS NULL",
+            (user_id,),
+        )
+        row = cur.fetchone()
+        return dict(row) if row else None

--- a/app/config.py
+++ b/app/config.py
@@ -1,0 +1,41 @@
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+APP_DIR = Path(__file__).resolve().parent
+REPO_ROOT = APP_DIR.parent
+
+load_dotenv(APP_DIR / ".env")
+
+
+@dataclass(frozen=True)
+class Settings:
+    google_client_id: str
+    google_client_secret: str
+    session_secret: str
+    db_path: Path
+    content_dir: Path
+    cookie_secure: bool
+
+
+def _require(name: str) -> str:
+    value = os.getenv(name, "").strip()
+    if not value:
+        raise RuntimeError(f"Missing required env var: {name}. See app/.env.example.")
+    return value
+
+
+def load_settings() -> Settings:
+    return Settings(
+        google_client_id=_require("GOOGLE_OAUTH_CLIENT_ID"),
+        google_client_secret=_require("GOOGLE_OAUTH_CLIENT_SECRET"),
+        session_secret=_require("SESSION_SECRET"),
+        db_path=Path(os.getenv("DB_PATH", str(APP_DIR / "paperpulse.sqlite"))),
+        content_dir=Path(os.getenv("CONTENT_DIR", str(REPO_ROOT / "content"))),
+        cookie_secure=os.getenv("COOKIE_SECURE", "false").lower() == "true",
+    )
+
+
+settings = load_settings()

--- a/app/data/categories.json
+++ b/app/data/categories.json
@@ -1,0 +1,1087 @@
+[
+  {
+    "slug": "astro-ph.CO",
+    "display_name": "Cosmology and Nongalactic Astrophysics",
+    "archive": "astro-ph",
+    "description": "Phenomenology of early universe, cosmic microwave background, cosmological parameters.",
+    "rss_url": "https://rss.arxiv.org/rss/astro-ph.CO"
+  },
+  {
+    "slug": "astro-ph.EP",
+    "display_name": "Earth and Planetary Astrophysics",
+    "archive": "astro-ph",
+    "description": "Interplanetary medium, planetary physics, planetary astrobiology, extrasolar planets.",
+    "rss_url": "https://rss.arxiv.org/rss/astro-ph.EP"
+  },
+  {
+    "slug": "astro-ph.GA",
+    "display_name": "Astrophysics of Galaxies",
+    "archive": "astro-ph",
+    "description": "Phenomena pertaining to galaxies or the Milky Way. Star clusters, HII regions and planetary nebulae.",
+    "rss_url": "https://rss.arxiv.org/rss/astro-ph.GA"
+  },
+  {
+    "slug": "astro-ph.HE",
+    "display_name": "High Energy Astrophysical Phenomena",
+    "archive": "astro-ph",
+    "description": "Cosmic ray production, acceleration, propagation, detection. Gamma ray astronomy and bursts.",
+    "rss_url": "https://rss.arxiv.org/rss/astro-ph.HE"
+  },
+  {
+    "slug": "astro-ph.IM",
+    "display_name": "Instrumentation and Methods for Astrophysics",
+    "archive": "astro-ph",
+    "description": "Detector and telescope design, experiment proposals. Laboratory Astrophysics.",
+    "rss_url": "https://rss.arxiv.org/rss/astro-ph.IM"
+  },
+  {
+    "slug": "astro-ph.SR",
+    "display_name": "Solar and Stellar Astrophysics",
+    "archive": "astro-ph",
+    "description": "White dwarfs, brown dwarfs, cataclysmic variables. Star formation and protostellar systems.",
+    "rss_url": "https://rss.arxiv.org/rss/astro-ph.SR"
+  },
+  {
+    "slug": "cond-mat.dis-nn",
+    "display_name": "Disordered Systems and Neural Networks",
+    "archive": "cond-mat",
+    "description": "Glasses and spin glasses; properties of random, aperiodic and quasiperiodic systems.",
+    "rss_url": "https://rss.arxiv.org/rss/cond-mat.dis-nn"
+  },
+  {
+    "slug": "cond-mat.mes-hall",
+    "display_name": "Mesoscale and Nanoscale Physics",
+    "archive": "cond-mat",
+    "description": "Semiconducting nanostructures: quantum dots, wires, and wells. Single electronics, spintronics.",
+    "rss_url": "https://rss.arxiv.org/rss/cond-mat.mes-hall"
+  },
+  {
+    "slug": "cond-mat.mtrl-sci",
+    "display_name": "Materials Science",
+    "archive": "cond-mat",
+    "description": "Techniques, synthesis, characterization, structure. Structural phase transitions, mechanical properties.",
+    "rss_url": "https://rss.arxiv.org/rss/cond-mat.mtrl-sci"
+  },
+  {
+    "slug": "cond-mat.other",
+    "display_name": "Other Condensed Matter",
+    "archive": "cond-mat",
+    "description": "Work in condensed matter that does not fit into the other cond-mat classifications.",
+    "rss_url": "https://rss.arxiv.org/rss/cond-mat.other"
+  },
+  {
+    "slug": "cond-mat.quant-gas",
+    "display_name": "Quantum Gases",
+    "archive": "cond-mat",
+    "description": "Ultracold atomic and molecular gases, Bose-Einstein condensation, Feshbach resonances.",
+    "rss_url": "https://rss.arxiv.org/rss/cond-mat.quant-gas"
+  },
+  {
+    "slug": "cond-mat.soft",
+    "display_name": "Soft Condensed Matter",
+    "archive": "cond-mat",
+    "description": "Membranes, polymers, liquid crystals, glasses, colloids, granular matter.",
+    "rss_url": "https://rss.arxiv.org/rss/cond-mat.soft"
+  },
+  {
+    "slug": "cond-mat.stat-mech",
+    "display_name": "Statistical Mechanics",
+    "archive": "cond-mat",
+    "description": "Phase transitions, thermodynamics, field theory, non-equilibrium phenomena.",
+    "rss_url": "https://rss.arxiv.org/rss/cond-mat.stat-mech"
+  },
+  {
+    "slug": "cond-mat.str-el",
+    "display_name": "Strongly Correlated Electrons",
+    "archive": "cond-mat",
+    "description": "Quantum magnetism, non-Fermi liquids, spin liquids, quantum criticality.",
+    "rss_url": "https://rss.arxiv.org/rss/cond-mat.str-el"
+  },
+  {
+    "slug": "cond-mat.supr-con",
+    "display_name": "Superconductivity",
+    "archive": "cond-mat",
+    "description": "Superconductivity: theory, models, experiment. Superflow in helium.",
+    "rss_url": "https://rss.arxiv.org/rss/cond-mat.supr-con"
+  },
+  {
+    "slug": "cs.AI",
+    "display_name": "Artificial Intelligence",
+    "archive": "cs",
+    "description": "Covers all areas of AI except Vision, Robotics, Machine Learning, Multiagent Systems, and Computation and Language (Natural Language Processing), which have separate subject areas.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.AI"
+  },
+  {
+    "slug": "cs.AR",
+    "display_name": "Hardware Architecture",
+    "archive": "cs",
+    "description": "Covers systems organization and hardware architecture.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.AR"
+  },
+  {
+    "slug": "cs.CC",
+    "display_name": "Computational Complexity",
+    "archive": "cs",
+    "description": "Covers models of computation, complexity classes, structural complexity, complexity tradeoffs, upper and lower bounds.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.CC"
+  },
+  {
+    "slug": "cs.CE",
+    "display_name": "Computational Engineering, Finance, and Science",
+    "archive": "cs",
+    "description": "Covers applications of computer science to the mathematical modeling of complex systems in the fields of science, engineering, and finance.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.CE"
+  },
+  {
+    "slug": "cs.CG",
+    "display_name": "Computational Geometry",
+    "archive": "cs",
+    "description": "Roughly includes material in ACM Subject Classes I.3.5 and F.2.2.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.CG"
+  },
+  {
+    "slug": "cs.CL",
+    "display_name": "Computation and Language",
+    "archive": "cs",
+    "description": "Covers natural language processing.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.CL"
+  },
+  {
+    "slug": "cs.CR",
+    "display_name": "Cryptography and Security",
+    "archive": "cs",
+    "description": "Covers all areas of cryptography and security including authentication, public key cryptosytems, proof-carrying code, etc.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.CR"
+  },
+  {
+    "slug": "cs.CV",
+    "display_name": "Computer Vision and Pattern Recognition",
+    "archive": "cs",
+    "description": "Covers image processing, computer vision, pattern recognition, and scene understanding.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.CV"
+  },
+  {
+    "slug": "cs.CY",
+    "display_name": "Computers and Society",
+    "archive": "cs",
+    "description": "Covers impact of computers on society, computer ethics, information technology and public policy, legal aspects of computing, computers and education.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.CY"
+  },
+  {
+    "slug": "cs.DB",
+    "display_name": "Databases",
+    "archive": "cs",
+    "description": "Covers database management, datamining, and data processing.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.DB"
+  },
+  {
+    "slug": "cs.DC",
+    "display_name": "Distributed, Parallel, and Cluster Computing",
+    "archive": "cs",
+    "description": "Covers fault-tolerance, distributed algorithms, stabilility, parallel computation, and cluster computing.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.DC"
+  },
+  {
+    "slug": "cs.DL",
+    "display_name": "Digital Libraries",
+    "archive": "cs",
+    "description": "Covers all aspects of the digital library design and document and text creation.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.DL"
+  },
+  {
+    "slug": "cs.DM",
+    "display_name": "Discrete Mathematics",
+    "archive": "cs",
+    "description": "Covers combinatorics, graph theory, applications of probability.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.DM"
+  },
+  {
+    "slug": "cs.DS",
+    "display_name": "Data Structures and Algorithms",
+    "archive": "cs",
+    "description": "Covers data structures and analysis of algorithms.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.DS"
+  },
+  {
+    "slug": "cs.ET",
+    "display_name": "Emerging Technologies",
+    "archive": "cs",
+    "description": "Covers approaches to information processing based on alternatives to silicon CMOS-based technologies.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.ET"
+  },
+  {
+    "slug": "cs.FL",
+    "display_name": "Formal Languages and Automata Theory",
+    "archive": "cs",
+    "description": "Covers automata theory, formal language theory, grammars, and combinatorics on words.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.FL"
+  },
+  {
+    "slug": "cs.GL",
+    "display_name": "General Literature",
+    "archive": "cs",
+    "description": "Covers introductory material, survey material, predictions of future trends, biographies, and miscellaneous computer-science related material.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.GL"
+  },
+  {
+    "slug": "cs.GR",
+    "display_name": "Graphics",
+    "archive": "cs",
+    "description": "Covers all aspects of computer graphics.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.GR"
+  },
+  {
+    "slug": "cs.GT",
+    "display_name": "Computer Science and Game Theory",
+    "archive": "cs",
+    "description": "Covers all theoretical and applied aspects at the intersection of computer science and game theory.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.GT"
+  },
+  {
+    "slug": "cs.HC",
+    "display_name": "Human-Computer Interaction",
+    "archive": "cs",
+    "description": "Covers human factors, user interfaces, and collaborative computing.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.HC"
+  },
+  {
+    "slug": "cs.IR",
+    "display_name": "Information Retrieval",
+    "archive": "cs",
+    "description": "Covers indexing, dictionaries, retrieval, content and analysis.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.IR"
+  },
+  {
+    "slug": "cs.IT",
+    "display_name": "Information Theory",
+    "archive": "cs",
+    "description": "Covers theoretical and experimental aspects of information theory and coding.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.IT"
+  },
+  {
+    "slug": "cs.LG",
+    "display_name": "Machine Learning",
+    "archive": "cs",
+    "description": "Papers on all aspects of machine learning research including robustness, explanation, fairness, and methodology.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.LG"
+  },
+  {
+    "slug": "cs.LO",
+    "display_name": "Logic in Computer Science",
+    "archive": "cs",
+    "description": "Covers all aspects of logic in computer science, including finite model theory, logics of programs, modal logic, and program verification.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.LO"
+  },
+  {
+    "slug": "cs.MA",
+    "display_name": "Multiagent Systems",
+    "archive": "cs",
+    "description": "Covers multiagent systems, distributed artificial intelligence, intelligent agents, coordinated interactions. and practical applications.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.MA"
+  },
+  {
+    "slug": "cs.MM",
+    "display_name": "Multimedia",
+    "archive": "cs",
+    "description": "Roughly includes material in ACM Subject Class H.5.1.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.MM"
+  },
+  {
+    "slug": "cs.MS",
+    "display_name": "Mathematical Software",
+    "archive": "cs",
+    "description": "Roughly includes material in ACM Subject Class G.4.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.MS"
+  },
+  {
+    "slug": "cs.NA",
+    "display_name": "Numerical Analysis",
+    "archive": "cs",
+    "description": "cs.NA is an alias for math.NA.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.NA"
+  },
+  {
+    "slug": "cs.NE",
+    "display_name": "Neural and Evolutionary Computing",
+    "archive": "cs",
+    "description": "Covers neural networks, connectionism, genetic algorithms, artificial life, adaptive behavior.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.NE"
+  },
+  {
+    "slug": "cs.NI",
+    "display_name": "Networking and Internet Architecture",
+    "archive": "cs",
+    "description": "Covers all aspects of computer communication networks, including network architecture and design, network protocols, and internetwork standards.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.NI"
+  },
+  {
+    "slug": "cs.OH",
+    "display_name": "Other Computer Science",
+    "archive": "cs",
+    "description": "This is the classification to use for documents that do not fit anywhere else.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.OH"
+  },
+  {
+    "slug": "cs.OS",
+    "display_name": "Operating Systems",
+    "archive": "cs",
+    "description": "Roughly includes material in ACM Subject Classes D.4.1, D.4.2., D.4.3, D.4.4, D.4.5, D.4.7, and D.4.9.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.OS"
+  },
+  {
+    "slug": "cs.PF",
+    "display_name": "Performance",
+    "archive": "cs",
+    "description": "Covers performance measurement and evaluation, queueing, and simulation.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.PF"
+  },
+  {
+    "slug": "cs.PL",
+    "display_name": "Programming Languages",
+    "archive": "cs",
+    "description": "Covers programming language semantics, language features, programming approaches.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.PL"
+  },
+  {
+    "slug": "cs.RO",
+    "display_name": "Robotics",
+    "archive": "cs",
+    "description": "Roughly includes material in ACM Subject Class I.2.9.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.RO"
+  },
+  {
+    "slug": "cs.SC",
+    "display_name": "Symbolic Computation",
+    "archive": "cs",
+    "description": "Roughly includes material in ACM Subject Class I.1.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.SC"
+  },
+  {
+    "slug": "cs.SD",
+    "display_name": "Sound",
+    "archive": "cs",
+    "description": "Covers all aspects of computing with sound, and sound as an information channel.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.SD"
+  },
+  {
+    "slug": "cs.SE",
+    "display_name": "Software Engineering",
+    "archive": "cs",
+    "description": "Covers design tools, software metrics, testing and debugging, programming environments, etc.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.SE"
+  },
+  {
+    "slug": "cs.SI",
+    "display_name": "Social and Information Networks",
+    "archive": "cs",
+    "description": "Covers the design, analysis, and modeling of social and information networks.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.SI"
+  },
+  {
+    "slug": "cs.SY",
+    "display_name": "Systems and Control",
+    "archive": "cs",
+    "description": "cs.SY is an alias for eess.SY.",
+    "rss_url": "https://rss.arxiv.org/rss/cs.SY"
+  },
+  {
+    "slug": "econ.EM",
+    "display_name": "Econometrics",
+    "archive": "econ",
+    "description": "Econometric Theory, Micro-Econometrics, Macro-Econometrics, Empirical Content of Economic Relations discovered via New Methods.",
+    "rss_url": "https://rss.arxiv.org/rss/econ.EM"
+  },
+  {
+    "slug": "econ.GN",
+    "display_name": "General Economics",
+    "archive": "econ",
+    "description": "General methodological, applied, and empirical contributions to economics.",
+    "rss_url": "https://rss.arxiv.org/rss/econ.GN"
+  },
+  {
+    "slug": "econ.TH",
+    "display_name": "Theoretical Economics",
+    "archive": "econ",
+    "description": "Includes theoretical contributions to Contract Theory, Decision Theory, Game Theory, General Equilibrium, Growth, Learning and Evolution.",
+    "rss_url": "https://rss.arxiv.org/rss/econ.TH"
+  },
+  {
+    "slug": "eess.AS",
+    "display_name": "Audio and Speech Processing",
+    "archive": "eess",
+    "description": "Theory and methods for processing signals representing audio, speech, and language, and their applications.",
+    "rss_url": "https://rss.arxiv.org/rss/eess.AS"
+  },
+  {
+    "slug": "eess.IV",
+    "display_name": "Image and Video Processing",
+    "archive": "eess",
+    "description": "Theory, algorithms, and architectures for the formation, capture, processing, communication, analysis, and display of images, video.",
+    "rss_url": "https://rss.arxiv.org/rss/eess.IV"
+  },
+  {
+    "slug": "eess.SP",
+    "display_name": "Signal Processing",
+    "archive": "eess",
+    "description": "Theory, algorithms, performance analysis and applications of signal and data analysis.",
+    "rss_url": "https://rss.arxiv.org/rss/eess.SP"
+  },
+  {
+    "slug": "eess.SY",
+    "display_name": "Systems and Control",
+    "archive": "eess",
+    "description": "Theoretical and experimental research covering all facets of automatic control systems.",
+    "rss_url": "https://rss.arxiv.org/rss/eess.SY"
+  },
+  {
+    "slug": "gr-qc",
+    "display_name": "General Relativity and Quantum Cosmology",
+    "archive": "gr-qc",
+    "description": "Areas of gravitational physics, including experiments and observations related to the detection and interpretation of gravitational waves.",
+    "rss_url": "https://rss.arxiv.org/rss/gr-qc"
+  },
+  {
+    "slug": "hep-ex",
+    "display_name": "High Energy Physics - Experiment",
+    "archive": "hep-ex",
+    "description": "Results from high-energy/particle physics experiments and prospects for future experimental results.",
+    "rss_url": "https://rss.arxiv.org/rss/hep-ex"
+  },
+  {
+    "slug": "hep-lat",
+    "display_name": "High Energy Physics - Lattice",
+    "archive": "hep-lat",
+    "description": "Lattice field theory. Phenomenology from lattice field theory. Algorithms for lattice field theory.",
+    "rss_url": "https://rss.arxiv.org/rss/hep-lat"
+  },
+  {
+    "slug": "hep-ph",
+    "display_name": "High Energy Physics - Phenomenology",
+    "archive": "hep-ph",
+    "description": "Theoretical particle physics and its interrelation with experiment.",
+    "rss_url": "https://rss.arxiv.org/rss/hep-ph"
+  },
+  {
+    "slug": "hep-th",
+    "display_name": "High Energy Physics - Theory",
+    "archive": "hep-th",
+    "description": "Formal aspects of quantum field theory. String theory, supersymmetry and supergravity.",
+    "rss_url": "https://rss.arxiv.org/rss/hep-th"
+  },
+  {
+    "slug": "math.AC",
+    "display_name": "Commutative Algebra",
+    "archive": "math",
+    "description": "Commutative rings, modules, ideals, homological algebra, computational aspects, invariant theory.",
+    "rss_url": "https://rss.arxiv.org/rss/math.AC"
+  },
+  {
+    "slug": "math.AG",
+    "display_name": "Algebraic Geometry",
+    "archive": "math",
+    "description": "Algebraic varieties, stacks, sheaves, schemes, moduli spaces, complex geometry, quantum cohomology.",
+    "rss_url": "https://rss.arxiv.org/rss/math.AG"
+  },
+  {
+    "slug": "math.AP",
+    "display_name": "Analysis of PDEs",
+    "archive": "math",
+    "description": "Existence and uniqueness, boundary conditions, linear and non-linear operators, stability, soliton theory.",
+    "rss_url": "https://rss.arxiv.org/rss/math.AP"
+  },
+  {
+    "slug": "math.AT",
+    "display_name": "Algebraic Topology",
+    "archive": "math",
+    "description": "Homotopy theory, homological algebra, algebraic treatments of manifolds.",
+    "rss_url": "https://rss.arxiv.org/rss/math.AT"
+  },
+  {
+    "slug": "math.CA",
+    "display_name": "Classical Analysis and ODEs",
+    "archive": "math",
+    "description": "Special functions, orthogonal polynomials, harmonic analysis, ODE's, differential relations.",
+    "rss_url": "https://rss.arxiv.org/rss/math.CA"
+  },
+  {
+    "slug": "math.CO",
+    "display_name": "Combinatorics",
+    "archive": "math",
+    "description": "Discrete mathematics, graph theory, enumeration, combinatorial optimization, Ramsey theory.",
+    "rss_url": "https://rss.arxiv.org/rss/math.CO"
+  },
+  {
+    "slug": "math.CT",
+    "display_name": "Category Theory",
+    "archive": "math",
+    "description": "Enriched categories, topoi, abelian categories, monoidal categories, homological algebra.",
+    "rss_url": "https://rss.arxiv.org/rss/math.CT"
+  },
+  {
+    "slug": "math.CV",
+    "display_name": "Complex Variables",
+    "archive": "math",
+    "description": "Holomorphic functions, automorphic group actions and forms, pseudoconvexity, complex geometry.",
+    "rss_url": "https://rss.arxiv.org/rss/math.CV"
+  },
+  {
+    "slug": "math.DG",
+    "display_name": "Differential Geometry",
+    "archive": "math",
+    "description": "Complex, contact, Riemannian, pseudo-Riemannian and Finsler geometry, relativity, gauge theory.",
+    "rss_url": "https://rss.arxiv.org/rss/math.DG"
+  },
+  {
+    "slug": "math.DS",
+    "display_name": "Dynamical Systems",
+    "archive": "math",
+    "description": "Dynamics of differential equations and flows, mechanics, classical few-body problems, iterations.",
+    "rss_url": "https://rss.arxiv.org/rss/math.DS"
+  },
+  {
+    "slug": "math.FA",
+    "display_name": "Functional Analysis",
+    "archive": "math",
+    "description": "Banach spaces, function spaces, real functions, integral transforms, theory of distributions.",
+    "rss_url": "https://rss.arxiv.org/rss/math.FA"
+  },
+  {
+    "slug": "math.GM",
+    "display_name": "General Mathematics",
+    "archive": "math",
+    "description": "Mathematical material of general interest, topics not covered elsewhere.",
+    "rss_url": "https://rss.arxiv.org/rss/math.GM"
+  },
+  {
+    "slug": "math.GN",
+    "display_name": "General Topology",
+    "archive": "math",
+    "description": "Continuum theory, point-set topology, spaces with algebraic structure, foundations, dimension theory.",
+    "rss_url": "https://rss.arxiv.org/rss/math.GN"
+  },
+  {
+    "slug": "math.GR",
+    "display_name": "Group Theory",
+    "archive": "math",
+    "description": "Finite groups, topological groups, representation theory, cohomology, classification and structure.",
+    "rss_url": "https://rss.arxiv.org/rss/math.GR"
+  },
+  {
+    "slug": "math.GT",
+    "display_name": "Geometric Topology",
+    "archive": "math",
+    "description": "Manifolds, orbifolds, polyhedra, cell complexes, foliations, geometric structures.",
+    "rss_url": "https://rss.arxiv.org/rss/math.GT"
+  },
+  {
+    "slug": "math.HO",
+    "display_name": "History and Overview",
+    "archive": "math",
+    "description": "Biographies, philosophy of mathematics, mathematics education, recreational mathematics.",
+    "rss_url": "https://rss.arxiv.org/rss/math.HO"
+  },
+  {
+    "slug": "math.IT",
+    "display_name": "Information Theory",
+    "archive": "math",
+    "description": "math.IT is an alias for cs.IT.",
+    "rss_url": "https://rss.arxiv.org/rss/math.IT"
+  },
+  {
+    "slug": "math.KT",
+    "display_name": "K-Theory and Homology",
+    "archive": "math",
+    "description": "Algebraic and topological K-theory, relations with topology, commutative algebra.",
+    "rss_url": "https://rss.arxiv.org/rss/math.KT"
+  },
+  {
+    "slug": "math.LO",
+    "display_name": "Logic",
+    "archive": "math",
+    "description": "Logic, set theory, point-set topology, formal mathematics.",
+    "rss_url": "https://rss.arxiv.org/rss/math.LO"
+  },
+  {
+    "slug": "math.MG",
+    "display_name": "Metric Geometry",
+    "archive": "math",
+    "description": "Euclidean, hyperbolic, discrete, convex, coarse geometry, comparisons in Riemannian geometry.",
+    "rss_url": "https://rss.arxiv.org/rss/math.MG"
+  },
+  {
+    "slug": "math.MP",
+    "display_name": "Mathematical Physics",
+    "archive": "math",
+    "description": "Articles focus on areas of research that illustrate the application of mathematics to problems in physics.",
+    "rss_url": "https://rss.arxiv.org/rss/math.MP"
+  },
+  {
+    "slug": "math.NA",
+    "display_name": "Numerical Analysis",
+    "archive": "math",
+    "description": "Numerical algorithms for problems in analysis and algebra, scientific computation.",
+    "rss_url": "https://rss.arxiv.org/rss/math.NA"
+  },
+  {
+    "slug": "math.NT",
+    "display_name": "Number Theory",
+    "archive": "math",
+    "description": "Prime numbers, diophantine equations, analytic number theory, algebraic number theory.",
+    "rss_url": "https://rss.arxiv.org/rss/math.NT"
+  },
+  {
+    "slug": "math.OA",
+    "display_name": "Operator Algebras",
+    "archive": "math",
+    "description": "Algebras of operators on Hilbert space, C*-algebras, von Neumann algebras, non-commutative geometry.",
+    "rss_url": "https://rss.arxiv.org/rss/math.OA"
+  },
+  {
+    "slug": "math.OC",
+    "display_name": "Optimization and Control",
+    "archive": "math",
+    "description": "Operations research, linear programming, control theory, systems theory, optimal control, game theory.",
+    "rss_url": "https://rss.arxiv.org/rss/math.OC"
+  },
+  {
+    "slug": "math.PR",
+    "display_name": "Probability",
+    "archive": "math",
+    "description": "Theory and applications of probability and stochastic processes.",
+    "rss_url": "https://rss.arxiv.org/rss/math.PR"
+  },
+  {
+    "slug": "math.QA",
+    "display_name": "Quantum Algebra",
+    "archive": "math",
+    "description": "Quantum groups, skein theories, operadic and diagrammatic algebra, quantum field theory.",
+    "rss_url": "https://rss.arxiv.org/rss/math.QA"
+  },
+  {
+    "slug": "math.RA",
+    "display_name": "Rings and Algebras",
+    "archive": "math",
+    "description": "Non-commutative rings and algebras, non-associative algebras, universal algebra and lattice theory.",
+    "rss_url": "https://rss.arxiv.org/rss/math.RA"
+  },
+  {
+    "slug": "math.RT",
+    "display_name": "Representation Theory",
+    "archive": "math",
+    "description": "Linear representations of algebras and groups, Lie theory, associative algebras, multilinear algebra.",
+    "rss_url": "https://rss.arxiv.org/rss/math.RT"
+  },
+  {
+    "slug": "math.SG",
+    "display_name": "Symplectic Geometry",
+    "archive": "math",
+    "description": "Hamiltonian systems, symplectic flows, classical integrable systems.",
+    "rss_url": "https://rss.arxiv.org/rss/math.SG"
+  },
+  {
+    "slug": "math.SP",
+    "display_name": "Spectral Theory",
+    "archive": "math",
+    "description": "Schrodinger operators, operators on manifolds, general differential operators.",
+    "rss_url": "https://rss.arxiv.org/rss/math.SP"
+  },
+  {
+    "slug": "math.ST",
+    "display_name": "Statistics Theory",
+    "archive": "math",
+    "description": "Applied, computational and theoretical statistics.",
+    "rss_url": "https://rss.arxiv.org/rss/math.ST"
+  },
+  {
+    "slug": "math-ph",
+    "display_name": "Mathematical Physics",
+    "archive": "math-ph",
+    "description": "Articles focus on areas of research that illustrate the application of mathematics to problems in physics.",
+    "rss_url": "https://rss.arxiv.org/rss/math-ph"
+  },
+  {
+    "slug": "nlin.AO",
+    "display_name": "Adaptation and Self-Organizing Systems",
+    "archive": "nlin",
+    "description": "Adaptation, self-organizing systems, statistical physics, fluctuating systems, stochastic processes.",
+    "rss_url": "https://rss.arxiv.org/rss/nlin.AO"
+  },
+  {
+    "slug": "nlin.CD",
+    "display_name": "Chaotic Dynamics",
+    "archive": "nlin",
+    "description": "Dynamical systems, chaos, quantum chaos, topological dynamics, cycle expansions, turbulence.",
+    "rss_url": "https://rss.arxiv.org/rss/nlin.CD"
+  },
+  {
+    "slug": "nlin.CG",
+    "display_name": "Cellular Automata and Lattice Gases",
+    "archive": "nlin",
+    "description": "Computational methods, time series analysis, signal processing, wavelets, lattice gases.",
+    "rss_url": "https://rss.arxiv.org/rss/nlin.CG"
+  },
+  {
+    "slug": "nlin.PS",
+    "display_name": "Pattern Formation and Solitons",
+    "archive": "nlin",
+    "description": "Pattern formation, coherent structures, solitons.",
+    "rss_url": "https://rss.arxiv.org/rss/nlin.PS"
+  },
+  {
+    "slug": "nlin.SI",
+    "display_name": "Exactly Solvable and Integrable Systems",
+    "archive": "nlin",
+    "description": "Exactly solvable systems, integrable PDEs, integrable ODEs, Painleve analysis.",
+    "rss_url": "https://rss.arxiv.org/rss/nlin.SI"
+  },
+  {
+    "slug": "nucl-ex",
+    "display_name": "Nuclear Experiment",
+    "archive": "nucl-ex",
+    "description": "Results from experimental nuclear physics including the areas of fundamental interactions.",
+    "rss_url": "https://rss.arxiv.org/rss/nucl-ex"
+  },
+  {
+    "slug": "nucl-th",
+    "display_name": "Nuclear Theory",
+    "archive": "nucl-th",
+    "description": "Theory of nuclear structure covering wide area from models of hadron structure to neutron stars.",
+    "rss_url": "https://rss.arxiv.org/rss/nucl-th"
+  },
+  {
+    "slug": "physics.acc-ph",
+    "display_name": "Accelerator Physics",
+    "archive": "physics",
+    "description": "Accelerator theory and simulation. Accelerator technology. Accelerator experiments. Beam Physics.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.acc-ph"
+  },
+  {
+    "slug": "physics.ao-ph",
+    "display_name": "Atmospheric and Oceanic Physics",
+    "archive": "physics",
+    "description": "Atmospheric and oceanic physics and physical chemistry, biogeophysics, and climate science.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.ao-ph"
+  },
+  {
+    "slug": "physics.app-ph",
+    "display_name": "Applied Physics",
+    "archive": "physics",
+    "description": "Applications of physics to new technology, including electronic devices, optics, photonics.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.app-ph"
+  },
+  {
+    "slug": "physics.atm-clus",
+    "display_name": "Atomic and Molecular Clusters",
+    "archive": "physics",
+    "description": "Atomic and molecular clusters, nanoparticles: geometric, electronic, optical, chemical properties.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.atm-clus"
+  },
+  {
+    "slug": "physics.atom-ph",
+    "display_name": "Atomic Physics",
+    "archive": "physics",
+    "description": "Atomic and molecular structure, spectra, collisions, and data. Atoms and molecules in external fields.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.atom-ph"
+  },
+  {
+    "slug": "physics.bio-ph",
+    "display_name": "Biological Physics",
+    "archive": "physics",
+    "description": "Molecular biophysics, cellular biophysics, neurological biophysics, membrane biophysics.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.bio-ph"
+  },
+  {
+    "slug": "physics.chem-ph",
+    "display_name": "Chemical Physics",
+    "archive": "physics",
+    "description": "Experimental, computational, and theoretical physics of atoms, molecules, and clusters.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.chem-ph"
+  },
+  {
+    "slug": "physics.class-ph",
+    "display_name": "Classical Physics",
+    "archive": "physics",
+    "description": "Newtonian and relativistic dynamics; many particle systems; planetary motions; chaos.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.class-ph"
+  },
+  {
+    "slug": "physics.comp-ph",
+    "display_name": "Computational Physics",
+    "archive": "physics",
+    "description": "All aspects of computational science applied to physics.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.comp-ph"
+  },
+  {
+    "slug": "physics.data-an",
+    "display_name": "Data Analysis, Statistics and Probability",
+    "archive": "physics",
+    "description": "Methods, software and hardware for physics data analysis: data processing and storage.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.data-an"
+  },
+  {
+    "slug": "physics.ed-ph",
+    "display_name": "Physics Education",
+    "archive": "physics",
+    "description": "Report of results of a research study, laboratory experience, assessment or classroom practice.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.ed-ph"
+  },
+  {
+    "slug": "physics.flu-dyn",
+    "display_name": "Fluid Dynamics",
+    "archive": "physics",
+    "description": "Turbulence, instabilities, incompressible/compressible flows, reacting flows.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.flu-dyn"
+  },
+  {
+    "slug": "physics.gen-ph",
+    "display_name": "General Physics",
+    "archive": "physics",
+    "description": "Description coming soon.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.gen-ph"
+  },
+  {
+    "slug": "physics.geo-ph",
+    "display_name": "Geophysics",
+    "archive": "physics",
+    "description": "Atmospheric physics. Biogeosciences. Computational geophysics. Geographic location.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.geo-ph"
+  },
+  {
+    "slug": "physics.hist-ph",
+    "display_name": "History and Philosophy of Physics",
+    "archive": "physics",
+    "description": "History and philosophy of all branches of physics, astrophysics, and cosmology.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.hist-ph"
+  },
+  {
+    "slug": "physics.ins-det",
+    "display_name": "Instrumentation and Detectors",
+    "archive": "physics",
+    "description": "Instrumentation and Detectors for research in natural science.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.ins-det"
+  },
+  {
+    "slug": "physics.med-ph",
+    "display_name": "Medical Physics",
+    "archive": "physics",
+    "description": "Radiation therapy. Radiation dosimetry. Biomedical imaging modelling.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.med-ph"
+  },
+  {
+    "slug": "physics.optics",
+    "display_name": "Optics",
+    "archive": "physics",
+    "description": "Adaptive optics. Astronomical optics. Atmospheric optics. Biomedical optics.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.optics"
+  },
+  {
+    "slug": "physics.plasm-ph",
+    "display_name": "Plasma Physics",
+    "archive": "physics",
+    "description": "Fundamental plasma physics. Magnetically Confined Plasmas.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.plasm-ph"
+  },
+  {
+    "slug": "physics.pop-ph",
+    "display_name": "Popular Physics",
+    "archive": "physics",
+    "description": "Description coming soon.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.pop-ph"
+  },
+  {
+    "slug": "physics.soc-ph",
+    "display_name": "Physics and Society",
+    "archive": "physics",
+    "description": "Structure, dynamics and collective behavior of societies and groups.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.soc-ph"
+  },
+  {
+    "slug": "physics.space-ph",
+    "display_name": "Space Physics",
+    "archive": "physics",
+    "description": "Space plasma physics. Heliophysics. Space weather. Planetary magnetospheres.",
+    "rss_url": "https://rss.arxiv.org/rss/physics.space-ph"
+  },
+  {
+    "slug": "q-bio.BM",
+    "display_name": "Biomolecules",
+    "archive": "q-bio",
+    "description": "DNA, RNA, proteins, lipids, etc.; molecular structures and folding kinetics.",
+    "rss_url": "https://rss.arxiv.org/rss/q-bio.BM"
+  },
+  {
+    "slug": "q-bio.CB",
+    "display_name": "Cell Behavior",
+    "archive": "q-bio",
+    "description": "Cell-cell signaling and interaction; morphogenesis and development; apoptosis.",
+    "rss_url": "https://rss.arxiv.org/rss/q-bio.CB"
+  },
+  {
+    "slug": "q-bio.GN",
+    "display_name": "Genomics",
+    "archive": "q-bio",
+    "description": "DNA sequencing and assembly; gene and motif finding; RNA editing and alternative splicing.",
+    "rss_url": "https://rss.arxiv.org/rss/q-bio.GN"
+  },
+  {
+    "slug": "q-bio.MN",
+    "display_name": "Molecular Networks",
+    "archive": "q-bio",
+    "description": "Gene regulation, signal transduction, proteomics, metabolomics, gene and enzymatic networks.",
+    "rss_url": "https://rss.arxiv.org/rss/q-bio.MN"
+  },
+  {
+    "slug": "q-bio.NC",
+    "display_name": "Neurons and Cognition",
+    "archive": "q-bio",
+    "description": "Synapse, cortex, neuronal dynamics, neural network, sensorimotor control, behavior.",
+    "rss_url": "https://rss.arxiv.org/rss/q-bio.NC"
+  },
+  {
+    "slug": "q-bio.OT",
+    "display_name": "Other Quantitative Biology",
+    "archive": "q-bio",
+    "description": "Work in quantitative biology that does not fit into the other q-bio classifications.",
+    "rss_url": "https://rss.arxiv.org/rss/q-bio.OT"
+  },
+  {
+    "slug": "q-bio.PE",
+    "display_name": "Populations and Evolution",
+    "archive": "q-bio",
+    "description": "Population dynamics, spatio-temporal and epidemiological models, dynamic speciation.",
+    "rss_url": "https://rss.arxiv.org/rss/q-bio.PE"
+  },
+  {
+    "slug": "q-bio.QM",
+    "display_name": "Quantitative Methods",
+    "archive": "q-bio",
+    "description": "All experimental, numerical, statistical and mathematical contributions of value to biology.",
+    "rss_url": "https://rss.arxiv.org/rss/q-bio.QM"
+  },
+  {
+    "slug": "q-bio.SC",
+    "display_name": "Subcellular Processes",
+    "archive": "q-bio",
+    "description": "Assembly and control of subcellular structures; molecular motors, transport.",
+    "rss_url": "https://rss.arxiv.org/rss/q-bio.SC"
+  },
+  {
+    "slug": "q-bio.TO",
+    "display_name": "Tissues and Organs",
+    "archive": "q-bio",
+    "description": "Blood flow in vessels, biomechanics of bones, electrical waves, endocrine system, tumor growth.",
+    "rss_url": "https://rss.arxiv.org/rss/q-bio.TO"
+  },
+  {
+    "slug": "q-fin.CP",
+    "display_name": "Computational Finance",
+    "archive": "q-fin",
+    "description": "Computational methods, including Monte Carlo, PDE, lattice and other numerical methods with applications to financial modeling.",
+    "rss_url": "https://rss.arxiv.org/rss/q-fin.CP"
+  },
+  {
+    "slug": "q-fin.EC",
+    "display_name": "Economics",
+    "archive": "q-fin",
+    "description": "q-fin.EC is an alias for econ.GN.",
+    "rss_url": "https://rss.arxiv.org/rss/q-fin.EC"
+  },
+  {
+    "slug": "q-fin.GN",
+    "display_name": "General Finance",
+    "archive": "q-fin",
+    "description": "Development of general quantitative methodologies with applications in finance.",
+    "rss_url": "https://rss.arxiv.org/rss/q-fin.GN"
+  },
+  {
+    "slug": "q-fin.MF",
+    "display_name": "Mathematical Finance",
+    "archive": "q-fin",
+    "description": "Mathematical and analytical methods of finance, including stochastic, probabilistic and functional analysis.",
+    "rss_url": "https://rss.arxiv.org/rss/q-fin.MF"
+  },
+  {
+    "slug": "q-fin.PM",
+    "display_name": "Portfolio Management",
+    "archive": "q-fin",
+    "description": "Security selection and optimization, capital allocation, investment strategies.",
+    "rss_url": "https://rss.arxiv.org/rss/q-fin.PM"
+  },
+  {
+    "slug": "q-fin.PR",
+    "display_name": "Pricing of Securities",
+    "archive": "q-fin",
+    "description": "Valuation and hedging of financial securities, their derivatives, and structured products.",
+    "rss_url": "https://rss.arxiv.org/rss/q-fin.PR"
+  },
+  {
+    "slug": "q-fin.RM",
+    "display_name": "Risk Management",
+    "archive": "q-fin",
+    "description": "Measurement and management of financial risks in trading, banking, insurance.",
+    "rss_url": "https://rss.arxiv.org/rss/q-fin.RM"
+  },
+  {
+    "slug": "q-fin.ST",
+    "display_name": "Statistical Finance",
+    "archive": "q-fin",
+    "description": "Statistical, econometric and econophysics analyses with applications to financial markets.",
+    "rss_url": "https://rss.arxiv.org/rss/q-fin.ST"
+  },
+  {
+    "slug": "q-fin.TR",
+    "display_name": "Trading and Market Microstructure",
+    "archive": "q-fin",
+    "description": "Market microstructure, liquidity, exchange and auction design, automated trading.",
+    "rss_url": "https://rss.arxiv.org/rss/q-fin.TR"
+  },
+  {
+    "slug": "quant-ph",
+    "display_name": "Quantum Physics",
+    "archive": "quant-ph",
+    "description": "Description coming soon.",
+    "rss_url": "https://rss.arxiv.org/rss/quant-ph"
+  },
+  {
+    "slug": "stat.AP",
+    "display_name": "Applications",
+    "archive": "stat",
+    "description": "Biology, Education, Epidemiology, Engineering, Environmental Sciences, Medical.",
+    "rss_url": "https://rss.arxiv.org/rss/stat.AP"
+  },
+  {
+    "slug": "stat.CO",
+    "display_name": "Computation",
+    "archive": "stat",
+    "description": "Algorithms, Simulation, Visualization.",
+    "rss_url": "https://rss.arxiv.org/rss/stat.CO"
+  },
+  {
+    "slug": "stat.ME",
+    "display_name": "Methodology",
+    "archive": "stat",
+    "description": "Design, Surveys, Model Selection, Multiple Testing, Multivariate Methods.",
+    "rss_url": "https://rss.arxiv.org/rss/stat.ME"
+  },
+  {
+    "slug": "stat.ML",
+    "display_name": "Machine Learning",
+    "archive": "stat",
+    "description": "Covers machine learning papers with a statistical or theoretical grounding.",
+    "rss_url": "https://rss.arxiv.org/rss/stat.ML"
+  },
+  {
+    "slug": "stat.OT",
+    "display_name": "Other Statistics",
+    "archive": "stat",
+    "description": "Work in statistics that does not fit into the other stat classifications.",
+    "rss_url": "https://rss.arxiv.org/rss/stat.OT"
+  },
+  {
+    "slug": "stat.TH",
+    "display_name": "Statistics Theory",
+    "archive": "stat",
+    "description": "stat.TH is an alias for math.ST.",
+    "rss_url": "https://rss.arxiv.org/rss/stat.TH"
+  }
+]

--- a/app/db.py
+++ b/app/db.py
@@ -1,0 +1,30 @@
+import sqlite3
+from contextlib import contextmanager
+from pathlib import Path
+
+from app.config import APP_DIR, settings
+
+SCHEMA_PATH = APP_DIR / "schema.sql"
+
+
+def _connect(path: Path) -> sqlite3.Connection:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path, isolation_level=None, check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA foreign_keys = ON;")
+    return conn
+
+
+@contextmanager
+def get_conn():
+    conn = _connect(settings.db_path)
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def init_db() -> None:
+    with get_conn() as conn:
+        with open(SCHEMA_PATH, "r", encoding="utf-8") as f:
+            conn.executescript(f.read())

--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,28 @@
+from fastapi import FastAPI
+from starlette.middleware.sessions import SessionMiddleware
+
+from app.auth import router as auth_router
+from app.config import settings
+from app.db import init_db
+from app.routes import router as routes_router
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(title="PaperPulse")
+    app.add_middleware(
+        SessionMiddleware,
+        secret_key=settings.session_secret,
+        https_only=settings.cookie_secure,
+        same_site="lax",
+    )
+    app.include_router(auth_router)
+    app.include_router(routes_router)
+
+    @app.on_event("startup")
+    def _startup() -> None:
+        init_db()
+
+    return app
+
+
+app = create_app()

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,0 +1,8 @@
+fastapi==0.115.6
+uvicorn[standard]==0.32.1
+authlib==1.3.2
+itsdangerous==2.2.0
+jinja2==3.1.4
+httpx==0.27.2
+python-dotenv==1.0.1
+pytest==8.3.4

--- a/app/routes.py
+++ b/app/routes.py
@@ -1,0 +1,30 @@
+from fastapi import APIRouter, Request
+from fastapi.responses import HTMLResponse, JSONResponse
+from fastapi.templating import Jinja2Templates
+
+from app.auth import current_user
+from app.config import APP_DIR
+from app.db import get_conn
+
+templates = Jinja2Templates(directory=str(APP_DIR / "templates"))
+
+router = APIRouter()
+
+
+@router.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    user = current_user(request)
+    return templates.TemplateResponse(
+        "index.html",
+        {"request": request, "user": user, "auth_error": request.query_params.get("auth_error")},
+    )
+
+
+@router.get("/healthz")
+async def healthz():
+    try:
+        with get_conn() as conn:
+            conn.execute("SELECT 1").fetchone()
+    except Exception as err:
+        return JSONResponse({"status": "error", "detail": str(err)}, status_code=500)
+    return {"status": "ok"}

--- a/app/schema.sql
+++ b/app/schema.sql
@@ -1,0 +1,44 @@
+PRAGMA journal_mode = WAL;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS users (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  google_sub TEXT NOT NULL UNIQUE,
+  email TEXT NOT NULL,
+  display_name TEXT,
+  picture_url TEXT,
+  created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  updated_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  deleted_at TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_users_email ON users(email);
+
+CREATE TABLE IF NOT EXISTS categories (
+  slug TEXT PRIMARY KEY,
+  display_name TEXT NOT NULL,
+  description TEXT,
+  rss_url TEXT NOT NULL,
+  active INTEGER NOT NULL DEFAULT 1,
+  sort_order INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS user_categories (
+  user_id INTEGER NOT NULL,
+  category_slug TEXT NOT NULL,
+  created_at TEXT NOT NULL DEFAULT (CURRENT_TIMESTAMP),
+  PRIMARY KEY (user_id, category_slug),
+  FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+  FOREIGN KEY (category_slug) REFERENCES categories(slug)
+);
+
+CREATE TABLE IF NOT EXISTS daily_runs (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  run_date TEXT NOT NULL,
+  started_at TEXT NOT NULL,
+  completed_at TEXT,
+  status TEXT NOT NULL,
+  error_message TEXT,
+  categories_completed INTEGER NOT NULL DEFAULT 0,
+  categories_total INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_daily_runs_date ON daily_runs(run_date);

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,20 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>{% block title %}PaperPulse{% endblock %}</title>
+  <meta name="robots" content="noindex">
+</head>
+<body>
+  <header>
+    <strong>PaperPulse</strong>
+    {% if user %}
+      <span>{{ user.email }}</span>
+      <a href="/auth/logout">Sign out</a>
+    {% else %}
+      <a href="/auth/login">Sign in with Google</a>
+    {% endif %}
+  </header>
+  <main>{% block content %}{% endblock %}</main>
+</body>
+</html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %}
+{% block content %}
+  {% if auth_error %}
+    <p>Auth error: {{ auth_error }}</p>
+  {% endif %}
+  {% if user %}
+    <h1>Hello, {{ user.display_name or user.email }}</h1>
+    <p>Signed in as {{ user.email }}.</p>
+    <p>Next: category picker (not built yet).</p>
+  {% else %}
+    <h1>PaperPulse</h1>
+    <p>Personalized arXiv summaries. Sign in with Google to get started.</p>
+  {% endif %}
+{% endblock %}

--- a/app/tests/conftest.py
+++ b/app/tests/conftest.py
@@ -1,0 +1,24 @@
+"""Test fixtures and bootstrap.
+
+Env vars must be set BEFORE any `app.*` module is imported, because
+`app.config` reads them at import time and freezes them into a dataclass.
+"""
+import os
+import tempfile
+
+_TMP_DIR = tempfile.mkdtemp(prefix="paperpulse-tests-")
+os.environ.setdefault("GOOGLE_OAUTH_CLIENT_ID", "test-client-id")
+os.environ.setdefault("GOOGLE_OAUTH_CLIENT_SECRET", "test-client-secret")
+os.environ.setdefault("SESSION_SECRET", "test-session-secret-do-not-use-in-prod")
+os.environ.setdefault("DB_PATH", os.path.join(_TMP_DIR, "test.sqlite"))
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture(scope="session")
+def client():
+    from app.main import app
+
+    with TestClient(app) as c:
+        yield c

--- a/app/tests/test_smoke.py
+++ b/app/tests/test_smoke.py
@@ -1,0 +1,10 @@
+def test_healthz_returns_ok(client):
+    response = client.get("/healthz")
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+def test_index_renders_for_anonymous(client):
+    response = client.get("/")
+    assert response.status_code == 200
+    assert "Sign in with Google" in response.text

--- a/docs/GOAL_AUTONOMY.md
+++ b/docs/GOAL_AUTONOMY.md
@@ -1,0 +1,80 @@
+# `/goal` autonomy boundary
+
+Rules for what Claude may do without per-turn confirmation when running under
+`/goal`. Overrides nothing in `CLAUDE.md`; this just narrows the gate for
+goal-mode runs.
+
+When auto mode is on AND `/goal` is active, the items under **In-scope** run
+without prompting. Everything under **Hard-gated** still requires explicit
+confirmation in the current message, even mid-goal.
+
+If a goal condition appears to require a hard-gated action, Claude must stop
+the goal, surface the gap, and wait for instruction.
+
+---
+
+## In-scope (no per-action confirmation)
+
+Filesystem (under `app/` and `docs/` only):
+- Create, edit, delete files under `app/**` and `app/tests/**`
+- Create, edit `docs/**`
+- Read any file in the repo
+
+Local commands:
+- `pytest`, `python -m ...` against local code
+- `pip install` into `app/.venv/` (for adding test deps already in `requirements.txt`)
+- Read-only git: `git status`, `git diff`, `git log`, `git show`
+- `sqlite3` against the local dev DB (`app/paperpulse.sqlite`) or test tmpdir DBs
+
+Network:
+- Local only: `curl http://localhost:*`, `curl http://127.0.0.1:*`
+
+---
+
+## Hard-gated (requires explicit confirmation in current message)
+
+Even during an active `/goal` run, Claude must stop and ask before:
+
+Git state changes:
+- `git commit`, `git push`, `git pull`, `git rebase`, `git merge`
+- Branch creation, deletion, checkout to a different branch
+- Any `git reset`, `git restore`, `git clean`
+- Tag creation or modification
+
+Files outside `app/` and `docs/`:
+- Anything under `api/`, `blog/`, `nginx/`, `systemd/`, `scripts/`
+- `.github/**` (CI/CD)
+- `docker-compose*.yml`, `Dockerfile*`
+- `.gitignore`, `CLAUDE.md`, `setup.py`, `requirements.txt` at repo root
+- This file (`docs/GOAL_AUTONOMY.md`) — boundary changes require human approval
+
+External services:
+- Any `curl`/`wget`/`httpx` to a non-localhost URL
+- Any call to Gemini, Google APIs, GitHub API, DigitalOcean, OAuth providers
+- Any `ssh`, `scp`, `rsync` to a remote
+- Any `docker`, `docker compose` command
+- Any deploy script under `scripts/`
+
+Destructive ops:
+- `rm -rf` of anything beyond the test tmpdir
+- Dropping DB tables, truncating prod-shaped data
+- Killing processes that aren't ones Claude started in this session
+- `--no-verify`, `--force`, `--no-gpg-sign` flags on any command
+
+PII / secrets:
+- Reading or echoing `app/.env`, `api/.env`, `/var/lib/paperpulse/secrets/**`
+- Writing real secrets into any file
+- Logging email addresses or display names
+
+---
+
+## How to invoke a goal under this boundary
+
+1. Make sure auto mode is on (`/auto`).
+2. Set the goal with a condition expressed as a pytest assertion or curl-checkable HTTP response — see `docs/PHASE1_CHUNKS.md` for examples.
+3. Claude works within the in-scope set; pauses when a hard-gated step is needed.
+
+Example:
+```
+/goal pytest app/tests passes including new tests covering all acceptance criteria in docs/PHASE1_CHUNKS.md chunk 1
+```

--- a/docs/PHASE1_CHUNKS.md
+++ b/docs/PHASE1_CHUNKS.md
@@ -1,0 +1,74 @@
+# Phase 1 — chunked acceptance criteria
+
+Each chunk lists a single verifiable end state, broken into pytest-shaped
+assertions. Used as the source of truth for `/goal` runs.
+
+Test command (from repo root):
+```
+PYTHONPATH=. app/.venv/bin/pytest app/tests
+```
+
+---
+
+## Chunk 0 — Skeleton (DONE)
+
+Acceptance:
+- [x] `GET /healthz` returns 200 `{"status": "ok"}`
+- [x] `GET /` returns 200 with "Sign in with Google" for an anonymous visitor
+- [x] Google OAuth round-trip works against `http://localhost:8000` (manual verification)
+- [x] User row upserted on first login (manual: confirmed via dogfood)
+
+---
+
+## Chunk 1 — Category seed + onboarding picker
+
+**Goal:** A logged-in user can pick 1–5 categories and have them persisted.
+
+Acceptance:
+- [ ] `app/data/categories.json` exists, committed, contains >= 100 arXiv subcategories with `slug`, `display_name`, `archive` (cs/stat/math/...), `rss_url`.
+- [ ] On `init_db()`, `categories` table is seeded from that JSON; re-running is idempotent (no duplicate rows, no errors).
+- [ ] `SELECT COUNT(*) FROM categories WHERE active = 1` matches the JSON row count.
+- [ ] `GET /onboarding` returns 200 for a logged-in user, 302 → `/auth/login` for anonymous.
+- [ ] `GET /onboarding` HTML contains all archives as group headers and a search input.
+- [ ] `POST /onboarding` with body `slugs=["cs.LG","cs.AI","cs.CL","cs.CV","stat.ML"]` for a logged-in user returns 302 → `/`, and `user_categories` has exactly 5 rows for that user.
+- [ ] `POST /onboarding` with 6 slugs returns 400 (cap-of-5 enforced server-side).
+- [ ] `POST /onboarding` with an unknown slug returns 400.
+- [ ] `POST /onboarding` for an anonymous request returns 401 or 302 → `/auth/login`.
+- [ ] After successful POST, `GET /` for that user redirects to `/feed` (or renders the feed placeholder — TBD when chunk 2 lands; for now just confirms session persists).
+- [ ] CSRF token required on `POST /onboarding`; missing/invalid token returns 403.
+
+Test scaffolding required:
+- An auth-injection fixture (dependency-override on `current_user`) so tests don't have to run a real OAuth round-trip. This is the place to add it.
+- A per-test DB reset fixture (truncate `users` and `user_categories` between tests) so test order doesn't matter.
+
+---
+
+## Chunk 2 — Feed page
+
+**Goal:** Logged-in user with selected categories sees today's per-category blurbs.
+
+Acceptance (draft — refine when chunk 1 lands):
+- [ ] `GET /feed` returns 200 for logged-in user with categories selected.
+- [ ] Response HTML contains one section per selected category, in alphabetical order by slug.
+- [ ] Each section contains the markdown rendered from `CONTENT_DIR/YYYY-MM-DD/<slug>.md`.
+- [ ] If a category's file is missing, section shows a "no new papers today" placeholder.
+- [ ] If the whole `YYYY-MM-DD/` dir is missing, page shows "pipeline runs at 6am Eastern" empty state.
+- [ ] "Today" is computed in `America/New_York`, not server UTC.
+- [ ] Anonymous `GET /feed` returns 302 → `/auth/login`.
+
+---
+
+## Chunk 3 — Settings + account deletion
+
+Acceptance (draft):
+- [ ] `GET /settings` shows current categories.
+- [ ] `POST /settings` updates `user_categories` (full replace, not append).
+- [ ] `POST /settings/delete-account` soft-deletes the user (`deleted_at` set), clears session.
+- [ ] After soft delete, `GET /` shows anonymous view.
+- [ ] CSRF tokens on both POSTs.
+
+---
+
+## Chunk 4 — Pipeline integration (per-category blurbs)
+
+Out of `app/` scope — touches `api/`. Hard-gated (see `docs/GOAL_AUTONOMY.md`).

--- a/docs/PHASE1_SPEC.md
+++ b/docs/PHASE1_SPEC.md
@@ -1,10 +1,10 @@
 # Phase 1 Spec — Profiles + Personalized Feed
 
 **Status:** Spec'd, not started
-**Last updated:** 2026-06-07
+**Last updated:** 2026-06-08
 
 ## What we're shipping
-Logged-in users sign in with Google, pick up to 5 categories from a curated list of ~20 arXiv cs.* subcategories, and see a personalized daily feed composed of per-category summaries. The existing public Jekyll archive at `paperpulse.ukurup.com` is untouched. The personalized experience lives at `app.paperpulse.ukurup.com`.
+Logged-in users sign in with Google, pick up to 5 categories from the full arXiv subcategory taxonomy (~150 subcategories across cs / stat / math / physics / q-bio / q-fin / eess / econ), and see a personalized daily feed composed of per-category summaries. The existing public Jekyll archive at `paperpulse.ukurup.com` is untouched. The personalized experience lives at `app.paperpulse.ukurup.com`.
 
 ## Goals
 - Users can sign in via Google OAuth, pick categories, and see a daily feed limited to those categories.
@@ -26,7 +26,7 @@ Logged-in users sign in with Google, pick up to 5 categories from a curated list
 1. User lands on `paperpulse.ukurup.com` (existing Jekyll archive). Header has a new "Sign in" link pointing to `app.paperpulse.ukurup.com`.
 2. App subdomain redirects to Google OAuth.
 3. Google redirects back with a code; app exchanges for tokens; session cookie set.
-4. First-time users: forced onboarding page — pick 1–5 categories from the curated list. Submit.
+4. First-time users: forced onboarding page — pick 1–5 categories from the full arXiv subcategory taxonomy. Picker is grouped by archive (cs, stat, math, physics, q-bio, q-fin, eess, econ) with a search box. Submit.
 5. Feed page: today's per-category summaries for the selected categories, concatenated, in a stable order (alphabetical by slug).
 6. Settings page: change selected categories, sign out, delete account.
 
@@ -117,7 +117,7 @@ CREATE INDEX idx_daily_runs_date ON daily_runs(run_date);
 Notes:
 - `users.google_sub` is the authoritative join key for OAuth, not email.
 - `users.deleted_at` is soft delete; a nightly purge can hard-delete after a grace period if desired.
-- `categories` is seeded once on first deploy from a static list (committed in the repo).
+- `categories` is seeded once on first deploy from a static list committed in the repo. The seed covers the full arXiv subcategory taxonomy (~150 entries). Idempotent re-seed on app startup so adding new arXiv categories later is a one-line config bump.
 - 5-category cap is enforced at the application layer when inserting into `user_categories`.
 - **Category popularity is queryable from `user_categories`.** Example: `SELECT category_slug, COUNT(*) AS users FROM user_categories WHERE user_id IN (SELECT id FROM users WHERE deleted_at IS NULL) GROUP BY category_slug ORDER BY users DESC;`. This gives a point-in-time snapshot of "which categories are most popular." Historical popularity (track adds/removes over time, e.g. churn per category) is NOT captured by this schema — if we want it, add an append-only `user_category_events` table later. Defer that until Phase 2 / when we actually need a trend.
 
@@ -149,18 +149,21 @@ Current flow (single combined summary):
 4. Write Jekyll post.
 
 New flow (combined + per-category):
-1. Fetch RSS for the curated ~20 cs.* categories.
-2. Dedup + filter to most recent pubDate.
-3. Continue: combined thematic summary → Jekyll post (public archive). Unchanged behavior.
-4. New: for each category, filter to papers tagged with that category and call Gemini with a per-category prompt → write `/var/lib/paperpulse/content/YYYY-MM-DD/<slug>.md`.
-5. Insert/update `daily_runs` row with status throughout.
+1. Compute the fetch list dynamically at run start: `SELECT DISTINCT category_slug FROM user_categories` UNION the fixed public-archive list (`cs.LG`, `cs.AI`, `cs.CL`, `cs.CV`, `stat.ML`). The fixed union guarantees the Jekyll archive keeps shipping even with zero users.
+2. Fetch RSS for that union.
+3. Dedup + filter to most recent pubDate.
+4. Continue: combined thematic summary over the fixed public-archive subset → Jekyll post. Unchanged behavior.
+5. New: for each category in the union, filter to papers tagged with that category and call Gemini with a per-category prompt → write `/var/lib/paperpulse/content/YYYY-MM-DD/<slug>.md`.
+6. Delete raw RSS feed data (in-memory parsed feeds, any on-disk intermediates) once the per-category markdown is written. Don't persist raw feeds across runs. The Jekyll post + per-category markdown files are the only durable artifacts.
+7. Insert/update `daily_runs` row with status throughout.
 
 **Design call: cross-listed papers appear in every relevant category's daily blurb.** Reasoning: a cs.CV reader who picks only cs.CV expects to see all cs.CV-relevant work, including papers primarily filed under cs.LG. Duplication for users selecting overlapping categories is an acceptable trade-off.
 
 Subtleties:
-- Per-category LLM passes add ~16 batches × 30s sleep ≈ ~8 extra minutes of pipeline time on top of current ~5 min. Existing systemd timeout is 30 min — verify in dev before assuming.
+- Pipeline runtime now scales with `len(distinct selected categories ∪ fixed public-archive list)`, not a fixed count. At 50 distinct categories × 30s inter-batch sleep that's already >25 min. Likely need to raise the systemd timeout, parallelize the LLM calls (within Gemini rate limits), or both. Decide during implementation once we see real numbers — don't pre-optimize.
 - If a category has zero new papers, skip the LLM call and write a placeholder file directly.
 - Empty-category placeholder is also useful when an LLM call fails — fail open with a "today's summary unavailable, see the public archive" line.
+- Raw RSS data is treated as ephemeral. No pickle cache in prod (already true), no JSON dumps left behind. The pipeline's persistent outputs are the Jekyll post, the per-category markdown files, and the `daily_runs` row.
 
 ## Deployment
 
@@ -188,7 +191,9 @@ DNS:
 - A record for `app.paperpulse.ukurup.com` pointing to the droplet.
 
 Backups:
-- Nightly cron: hot-backup `/var/lib/paperpulse/db/paperpulse.sqlite` via `.backup` or `VACUUM INTO` → off-droplet location (different host or small object store). Tested restore drill before launch.
+- Nightly systemd timer: hot-backup `/var/lib/paperpulse/db/paperpulse.sqlite` via `VACUUM INTO` (atomic, no lock contention with WAL writers) → upload to a **DigitalOcean Spaces** bucket (S3-compatible). Retain last 30 daily snapshots + last 12 monthly. Lifecycle rule on the bucket handles expiry.
+- Backup script lives at `/usr/local/bin/paperpulse-backup` and uses `s3cmd` or `aws s3` (with Spaces endpoint) authenticated via an access key stored in `/var/lib/paperpulse/secrets/spaces_credentials` (chmod 600, root-owned).
+- Tested restore drill before launch: download latest snapshot, open in `sqlite3`, run integrity check + sample queries.
 - `/var/lib/paperpulse/content` regenerates daily; backups nice-to-have, not load-bearing.
 
 ## Security & privacy
@@ -221,15 +226,16 @@ Privacy policy:
 2. **Redirect URI exact match.** Must match exactly including protocol, host, and path. Off-by-one trailing slash is the classic 30-minute debug.
 3. **`google_sub` is stable, email is not.** Always join by `google_sub`. If email changes upstream, update the column but never key off email.
 4. **Cookie domain trap.** Setting cookie domain to `.paperpulse.ukurup.com` would expose the session to the Jekyll site too — leave it scoped to the app subdomain only.
-5. **Pipeline runtime balloon.** ~20 LLM calls × 30s inter-batch sleep is real time. Verify against the 30-min systemd timeout; parallelize cautiously if it doesn't fit (rate limits).
+5. **Pipeline runtime balloon.** Runtime scales with the size of the dynamic fetch list. With 50+ distinct user-selected categories, current 30s inter-batch sleep blows past the 30-min systemd timeout. Plan to raise the timeout and/or parallelize within Gemini rate limits. Confirm with real numbers before launch.
 6. **Cross-listed papers** appear in multiple categories' summaries by design. Users selecting many overlapping categories will see some duplication; acceptable.
-7. **Empty-category days** for niche categories. Write a placeholder so the feed renders cleanly.
-8. **Time zone for "today."** Pipeline runs at 6am Eastern. The app should determine "today" using `America/New_York` to match the file layout, not server UTC.
-9. **SQLite write contention.** Pipeline writes `daily_runs`; app writes user data. WAL handles concurrent reads + one writer. Sanity-check it before launch.
-10. **Backup before launch.** Even one user lost is bad. Backup + restore drill before sending the sign-up link.
-11. **Logout doesn't kill the Google session.** Standard OAuth behavior; "Sign out" just kills the local session cookie. Worth a UX note if confusing.
-12. **GDPR-minimum compliance.** Privacy policy + working account-delete is the floor. Not a full compliance review.
-13. **Session secret rotation.** Rotating it logs everyone out. Plan a rotation policy or accept periodic forced logouts.
+7. **Raw feeds are ephemeral.** Don't persist raw RSS data across runs. Anything cached for debugging must be wiped at end-of-run. Avoids accidentally retaining paper metadata we never committed to keep.
+8. **Empty-category days** for niche categories. Write a placeholder so the feed renders cleanly.
+9. **Time zone for "today."** Pipeline runs at 6am Eastern. The app should determine "today" using `America/New_York` to match the file layout, not server UTC.
+10. **SQLite write contention.** Pipeline writes `daily_runs`; app writes user data. WAL handles concurrent reads + one writer. Sanity-check it before launch.
+11. **Backup before launch.** Even one user lost is bad. Backup + restore drill before sending the sign-up link.
+12. **Logout doesn't kill the Google session.** Standard OAuth behavior; "Sign out" just kills the local session cookie. Worth a UX note if confusing.
+13. **GDPR-minimum compliance.** Privacy policy + working account-delete is the floor. Not a full compliance review.
+14. **Session secret rotation.** Rotating it logs everyone out. Plan a rotation policy or accept periodic forced logouts.
 
 ## Low-hanging fruit (cheap wins worth doing in Phase 1)
 - `/healthz` endpoint (also satisfies Docker healthcheck).
@@ -243,12 +249,12 @@ Privacy policy:
 ## Sequencing (rough, solo-dev, evenings/weekends)
 1. **Foundations** — FastAPI skeleton, SQLite schema + migrations, Authlib + Google OAuth round-trip with a localhost redirect URI. Local dev only.
 2. **Onboarding + feed** — category picker page (with cap-of-5 enforcement), today's feed page reading from `/var/lib/paperpulse/content/`, settings page, account deletion.
-3. **Pipeline changes** — extend category list to ~20, add per-category Gemini passes, write to `/var/lib/paperpulse/content/`, populate `daily_runs`. Verify runtime fits the timeout.
+3. **Pipeline changes** — seed full arXiv subcategory taxonomy into `categories` table; switch fetch list to `DISTINCT user_categories ∪ fixed public-archive list`; add per-category Gemini passes; write to `/var/lib/paperpulse/content/`; populate `daily_runs`; delete raw feed data at end-of-run. Measure runtime against the timeout and parallelize if needed.
 4. **Deployment plumbing** — new subdomain DNS, nginx server block, Certbot SAN, new `app` service in `docker-compose.prod.yml`, persistent volumes, secrets, healthcheck. Manual deploy first; wire into existing CI/CD after.
 5. **Pre-launch hardening** — backup + restore drill, privacy policy page, GCP OAuth consent screen configured for production, end-to-end dogfood.
 6. **Soft launch** — invite-link to a small group; watch logs, fix issues, iterate before opening up.
 
 ## Open design questions (resolve during implementation; not blockers)
-- The exact curated list of ~20 cs.* subcategories. Quick pass: pick by paper volume + audience relevance. Easy to adjust post-launch.
+- Picker UI for ~150 subcategories. Lean: archive-grouped accordions (cs / stat / math / physics / q-bio / q-fin / eess / econ) with a search box. Confirm the archive list against current arXiv taxonomy before seeding.
 - Per-category prompt structure. Start with a literal adaptation of the current combined-summary prompt scoped to one category, then iterate on output quality.
 - Whether to keep the existing combined Jekyll summary indefinitely or eventually replace it with a "default" feed assembled from per-category content. Keep both for Phase 1.

--- a/docs/WORKLOG.md
+++ b/docs/WORKLOG.md
@@ -1,5 +1,145 @@
 # Worklog
 
+## Session: 2026-06-28 (Phase 1 chunk 0 — app skeleton + OAuth + /goal prep)
+
+### Worked on
+Stood up the new FastAPI app at `app/` per the Phase 1 spec. End-to-end Google OAuth login working locally. Added test scaffolding, acceptance-criteria doc, and a `/goal` autonomy boundary doc to make the next chunks runnable under Claude Code's `/goal` mode. Fetched the full arXiv subcategory taxonomy.
+
+### Completed
+
+**App skeleton (`app/`, new top-level dir)**
+- FastAPI + Jinja2 SSR + Authlib + SQLite (WAL, FK on). Files: `main.py`, `config.py`, `db.py`, `schema.sql`, `auth.py`, `routes.py`, `templates/{base,index}.html`, `requirements.txt` (pinned), `.env.example`, `README.md`.
+- `schema.sql` is verbatim from the spec — users / categories / user_categories / daily_runs.
+- `auth.py` does the OAuth round-trip and upserts users by `google_sub` (never by email).
+- Settings are loaded from `app/.env` (separate from `api/.env`) at import time into a frozen dataclass; `DB_PATH` and `CONTENT_DIR` env-overridable with sensible defaults.
+- `/healthz` returns 200 if DB is reachable.
+- `.gitignore` updated: `app/.env`, `app/.venv/`, `app/paperpulse.sqlite*`, `docs/internal-readme.md`.
+
+**End-to-end OAuth round-trip — verified locally**
+- Google Cloud OAuth client created in the new "Google Auth Platform" UI (was reorganized from the older "OAuth consent screen" flow). Scopes: openid, email, profile. Test-user mode. Redirect URI: `http://localhost:8000/auth/google/callback`.
+- Logged in successfully, came back as Unmesh / turingmachinesllc@gmail.com, user row upserted.
+
+**Test scaffold (`app/tests/`)**
+- `conftest.py` sets dummy OAuth env + tmpdir SQLite DB *before* any `app.*` import (config loads at import time, so order matters). Session-scoped `client` fixture using `TestClient`.
+- `test_smoke.py` — two passing tests: `/healthz` returns ok, anonymous `/` renders with "Sign in with Google".
+- Test command: `PYTHONPATH=. app/.venv/bin/pytest app/tests`.
+
+**Acceptance criteria + autonomy boundary for `/goal`**
+- `docs/PHASE1_CHUNKS.md` — chunks 0–3 broken into discrete, pytest-shaped acceptance criteria. Chunk 0 marked done; chunks 1–3 ready to drive `/goal` runs.
+- `docs/GOAL_AUTONOMY.md` — in-scope (file edits under `app/` and `docs/`, local pytest, read-only git, localhost curl) vs hard-gated (git state changes, files outside `app/`/`docs/`, all external network, docker, ssh, destructive ops, secrets). Hard-gated steps still require explicit confirmation even mid-goal.
+
+**arXiv taxonomy fetched + committed**
+- `app/data/categories.json` — 155 subcategories across all archives (cs 40, math 32, physics 22, etc.), sorted by `(archive, slug)`. Each row has `slug`, `display_name`, `archive`, `description`, `rss_url`.
+- RSS URL pattern (`https://rss.arxiv.org/rss/{slug}`) verified live for one dotted slug (`cs.LG`) and one bare slug (`quant-ph`) — both `HTTP 200 application/rss+xml`.
+- Known imperfection: aliased slugs (e.g. `cs.NA` ↔ `math.NA`, `cs.SY` ↔ `eess.SY`, several others) are all retained. Picker UI in chunk 1 needs an alias-dedupe call.
+
+### Decisions made
+- **`app/` as a new top-level dir**, not nested under `api/` and not via renaming `api/` → `pipeline/`. Matches the spec's "don't share venv with pipeline" intent without import-path churn. Naming inconsistency (`api/` is really the pipeline) accepted.
+- **`app/.env` separate from `api/.env`** — keeps the two deployables decoupled and matches the spec.
+- **`DB_PATH` env-configurable, default `app/paperpulse.sqlite`** — makes prod path (`/data/db/paperpulse.sqlite`) a one-env-var switch.
+- **Styling deferred** — dogfood with unstyled HTML. Theme port (Jekyll → app) happens as one focused pass once features are in place. Unmesh may pick a different design entirely.
+- **No on-the-fly dependency-injection refactor for `current_user`** in this chunk. Tests for auth-gated endpoints land in chunk 1 along with a proper `Depends()`-based `current_user` so test overrides are clean. Deliberately deferred to avoid scope creep here.
+- **Test scaffold uses one session-scoped DB** for now. Per-test reset fixture lands in chunk 1 when there's stateful data worth isolating.
+
+### Open follow-ups not blocking
+- Upgrade Claude Code to ≥ v2.1.139 to enable `/goal` (current install returned "Unknown command").
+- Two FastAPI deprecation warnings surfaced by pytest:
+  - `@app.on_event("startup")` → switch to lifespan handler
+  - `TemplateResponse(name, {"request": request, ...})` → switch to new `(request, name, ...)` signature
+  Both trivial; folding into chunk 1.
+- Alias-dedupe strategy for the category picker (chunk 1 design call).
+- Re-verify a few non-cs RSS URLs (e.g. `q-bio.NC`) before depending on them in the pipeline (chunk 4).
+- DigitalOcean Spaces backup setup still untouched — flagged as Track A from the access-setup walkthrough.
+- Privacy policy page (required to move OAuth consent screen out of Testing mode) — Phase 1 launch concern.
+- `docs/internal-readme.md` now gitignored (closing the prior open follow-up).
+
+### Next session priorities
+1. Run `/goal` against chunk 1 once Claude Code is upgraded. Goal condition: `pytest app/tests passes including new tests covering every acceptance criterion in chunk 1 of docs/PHASE1_CHUNKS.md`.
+2. Before launching: tighten chunk 1 acceptance criteria if anything reads vague on a re-skim.
+3. Add the `current_user` dependency + test override fixture as the first step of chunk 1.
+4. Address the two deprecation warnings as part of chunk 1.
+
+---
+
+## Session: 2026-06-08 (prod 502 — nginx stale upstream IP)
+
+### Worked on
+Diagnosed and fixed a prod 502 outage on `paperpulse.ukurup.com`.
+
+### Completed
+
+**Diagnosed: nginx caching stale blog container IP**
+- Symptom: `502 Bad Gateway` site-wide. nginx logs: `connect() failed (113: Host is unreachable) while connecting to upstream, upstream: "http://172.18.0.2:4000/"`.
+- Both `blog` and `nginx` containers were up and on the same Docker network (`arxivsum_web`). `docker exec arxivsum-nginx-1 wget http://blog:4000/` worked fine — DNS resolved `blog` to `172.18.0.4`, not `172.18.0.2`.
+- Root cause: nginx was up 46h, blog had been recreated 22h ago by the daily deploy. nginx's `proxy_pass http://blog:4000` resolves the hostname once at config-load time and caches the IP forever. When blog got a new IP after recreate, nginx kept proxying to the dead one.
+
+**Fix (`fix/nginx-runtime-resolver`, PR merged)**
+- Added `resolver 127.0.0.11 valid=10s ipv6=off;` (Docker's embedded DNS) + variable `proxy_pass` (`set $blog_upstream blog:4000; proxy_pass http://$blog_upstream;`) so nginx re-resolves at request time instead of caching at startup.
+- Added `proxy_connect_timeout 5s` + 60s read/send timeouts so a dead backend fails fast instead of defaulting to 60s connect.
+- After auto-deploy, still 502 — because `docker compose up -d` doesn't recreate nginx when only the bind-mounted config changes on disk. One-time `docker compose restart nginx` on the droplet loaded the new config; future recreates handled automatically now.
+
+### Decisions made
+- **Variable-based `proxy_pass` over `depends_on: [blog]` on nginx.** `depends_on` only controls startup order, not recreate ordering, so it doesn't fix recreate-time IP churn. Runtime resolver removes the deploy coupling entirely.
+- **Kept scheme outside the variable** (`set $blog_upstream blog:4000; proxy_pass http://$blog_upstream;` rather than putting `http://` inside the variable) — avoids subtle URI-rewrite bugs if a path is ever added to the proxy_pass target.
+- **No follow-up PR to auto-restart nginx on config change in the deploy script.** nginx config rarely changes; not worth the deploy-script complexity.
+
+### Next session priorities
+Unchanged from prior session: DO Spaces backup setup, Phase 1 foundations (FastAPI + SQLite + Authlib), seed arXiv taxonomy.
+
+### Open follow-ups not blocking
+- Deploy script doesn't restart nginx when `nginx/nginx.conf` changes on disk. Known gap; one manual `docker compose restart nginx` after such a change. Acceptable given how rarely the file changes.
+
+---
+
+## Session: 2026-06-07 → 2026-06-08 (Phase 1 spec + ops fix + chore PR)
+
+### Worked on
+Planning Phase 1 (Google login + personalized feeds), diagnosing a missing daily summary, and a small chore PR for doc reorg + content updates.
+
+### Completed
+
+**Phase 1 spec (`docs/PHASE1_SPEC.md`) + roadmap (`docs/ROADMAP.md`)**
+- Full spec for profiles + per-category feeds: Google OAuth via Authlib, FastAPI + Jinja2 SSR, SQLite (WAL) on a persistent volume, new `app.paperpulse.ukurup.com` subdomain, per-category markdown blurbs at `/var/lib/paperpulse/content/YYYY-MM-DD/<slug>.md`, Jekyll archive untouched.
+- Data model: `users` (joined by `google_sub`, soft delete), `categories`, `user_categories` (5-cap enforced at app layer), `daily_runs` ops table. Popularity query example in spec.
+- Roadmap captures Phase 2 (like/dislike learning loop, free-text categories with own summaries, daily email digest, hover-to-explain abstracts, pricing tiers via Stripe) and infra backlog (Prometheus, content index, Postgres migration).
+
+**Missing daily summary on 2026-06-07 — diagnosed + fixed (PR merged)**
+- Symptom: systemd timer fired but no blog post written; container exited 0 in 19s with no logs visible from host.
+- Root causes: (a) cs.LG RSS feed legitimately empty Sun morning (verified via WebFetch, not the Mon-Fri myth I initially overclaimed), (b) pipeline logs lived only inside the `--rm` run container so they vanished, (c) "no papers" path logged at error level and exited silently.
+- Fix on `fix/empty-feed-handling` branch: added `./logs:/app/logs` mount + `LOG_DIR` env to `api` service; switched logging to `FileHandler + StreamHandler(sys.stderr)` so journald captures output; downgraded "no papers" to info-level skip. Merged to main; CI moved `latest` to the new SHA.
+
+**Chore PR (`chore/docs-reorg-blog-readme`, merged)**
+- Moved all root-level docs to `docs/` (PHASE1_SPEC, ROADMAP, WORKLOG, ERRORS, DROPLET_SETUP, CICD_PLAN, ROLLBACK). Verified no broken refs in CI/scripts/systemd/nginx.
+- Added `stat.ML` to `RSS_CATEGORIES` in `api/settings.py`.
+- What's New v1.04 entry listing the full updated category set.
+- README intro updated for the new category list; replaced stale cron line with a Production deployment section pointing at CI/CD + systemd timer + `docs/` runbooks.
+
+**Phase 1 blockers resolved (spec updated)**
+- **Category scope:** free tier picks 5 from full arXiv subcategory taxonomy (~150), not a curated 20 cs.*. Picker grouped by archive (cs/stat/math/physics/q-bio/q-fin/eess/econ) with search.
+- **Pipeline fetch list:** dynamic — `SELECT DISTINCT category_slug FROM user_categories` UNION fixed public-archive list (`cs.LG`, `cs.AI`, `cs.CL`, `cs.CV`, `stat.ML`). Public archive keeps shipping with zero users.
+- **Raw feeds ephemeral:** added rule to delete RSS data after per-category markdown is written. Updated pipeline section + gotchas + sequencing.
+- **Cross-listed papers:** confirmed — appear in every relevant category's blurb.
+- **Backups:** locked in DO Spaces, `VACUUM INTO` snapshot, 30 daily + 12 monthly retention via lifecycle rules, credentials at `/var/lib/paperpulse/secrets/spaces_credentials`.
+
+### Decisions made
+- **Free-text categories deferred to Phase 2.** Considered moving them into Phase 1 with LLM topic→category mapping; rejected on YAGNI + scope grounds. Phase 1 stays a category picker, just over a much bigger universe.
+- **5-cap stays at 5 across the bigger taxonomy.** Cleaner than per-archive limits. Tier differentiation belongs in Phase 2 with Stripe.
+- **`daily_runs` table** included for ops visibility now (rather than waiting for a full Prometheus stack).
+- **`VACUUM INTO` over `.backup`** for SQLite snapshots — atomic, no lock contention with WAL writers.
+- **Backup runs from droplet (systemd timer)**, not CI — fewer moving parts. Open for revisit if we want off-host attestation.
+
+### Next session priorities
+- Set up the DO Spaces bucket (region, name, scoped access key, lifecycle rules). Then write `scripts/paperpulse-backup.sh`, systemd unit + timer, and `docs/BACKUP.md` runbook.
+- Begin Phase 1 implementation per spec sequencing — start with foundations (FastAPI skeleton, SQLite schema + migrations, Authlib + Google OAuth on localhost).
+- Fetch the live arXiv taxonomy to seed `categories` (one-time pull, commit the list).
+
+### Open follow-ups not blocking
+- Decide whether `docs/internal-readme.md` should be `.gitignore`'d (currently just untracked).
+- Confirm droplet region before creating the DO Space (lowest-latency match).
+- Pipeline runtime under the new dynamic fetch list — measure once we have real per-category Gemini passes; may need to raise systemd timeout or parallelize.
+
+---
+
 ## Session: 2026-06-06 (CI/CD landing + systemd timer)
 
 ### Worked on


### PR DESCRIPTION
Stand up new FastAPI app at app/ per Phase 1 spec, alongside the existing pipeline at api/. Google OAuth round-trip verified locally end-to-end.

App skeleton (app/):
- FastAPI + Jinja2 SSR + Authlib Google OAuth + SQLite (WAL, FK on)
- schema.sql: users, categories, user_categories, daily_runs (verbatim from spec)
- Users upserted by google_sub (never by email)
- Settings loaded from app/.env, separate from api/.env
- /healthz endpoint, session middleware, anonymous landing page

Test scaffold (app/tests/):
- pytest + FastAPI TestClient
- conftest sets dummy OAuth env + tmpdir DB before app imports
- Two passing smoke tests (/healthz, anonymous /)

arXiv taxonomy (app/data/categories.json):
- 155 subcategories across all archives
- Each row: slug, display_name, archive, description, rss_url
- RSS URL pattern verified live for dotted and bare slugs

Docs for /goal autonomous mode:
- docs/PHASE1_CHUNKS.md: chunks 0-3 as pytest-shaped acceptance criteria
- docs/GOAL_AUTONOMY.md: in-scope vs hard-gated rules for autonomous runs
- docs/PHASE1_SPEC.md: prior-session updates (full arXiv taxonomy scope, dynamic pipeline fetch list, ephemeral raw feeds, DO Spaces backups)