### PR TITLE
Fix all 18 open Dependabot alerts

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,10 +1,10 @@
 fastapi==0.115.6
 uvicorn[standard]==0.32.1
-authlib==1.3.2
+authlib==1.6.12
 itsdangerous==2.2.0
-jinja2==3.1.4
+jinja2==3.1.6
 markdown-it-py==4.2.0
 httpx==0.27.2
-python-dotenv==1.0.1
+python-dotenv==1.2.2
 tzdata==2026.3
-pytest==8.3.4
+pytest==9.0.3

--- a/blog/Gemfile.lock
+++ b/blog/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     colorator (1.1.0)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.3.7)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)


### PR DESCRIPTION
## Summary
Resolves all 18 open Dependabot alerts (1 critical, 5 high, 10 moderate, 2 low) across the two flagged manifests.

### `app/requirements.txt`
- **authlib 1.3.2 → 1.6.12** — 9 alerts, incl. critical JWS JWK header-injection signature bypass, JWE RSA1_5 padding oracle, OIDC open redirects, DoS via oversized JOSE segments
- **jinja2 3.1.4 → 3.1.6** — 3 sandbox-breakout alerts
- **python-dotenv 1.0.1 → 1.2.2** — symlink-following arbitrary file overwrite in `set_key`
- **pytest 8.3.4 → 9.0.3** — vulnerable tmpdir handling

### `blog/Gemfile.lock`
- **concurrent-ruby 1.1.10 → 1.3.7** — 3 alerts (read-count overflow grants write lock, `Float::NAN` livelock, wrong-thread lock release). Relocked inside the digest-pinned jekyll image from `Dockerfile.jekyll` so the diff is one line and `BUNDLED WITH` stays 2.3.25.

## Testing
- All 39 app tests pass with the new dependency versions (including the pytest 8→9 major bump)
- Jekyll blog builds cleanly with the updated lockfile in the prod-pinned jekyll image
- App usage of bumped packages is minimal/stable-API: authlib via `starlette_client.OAuth`, dotenv via `load_dotenv`, jinja2 via FastAPI `Jinja2Templates`

🤖 Generated with [Claude Code](https://claude.com/claude-code)