### PR TITLE
Shared left sidebar, login interstitial, logout banner, hard delete

### DIFF
--- a/app/auth.py
+++ b/app/auth.py
@@ -48,7 +48,8 @@ async def auth_callback(request: Request):
 @router.get("/logout")
 async def logout(request: Request):
     request.session.clear()
-    return RedirectResponse(url="/", status_code=HTTP_302_FOUND)
+    # Land on the main blog with a "logged out" banner (Phase 1 item 4).
+    return RedirectResponse(url=f"{settings.blog_url}/?logged_out=1", status_code=HTTP_302_FOUND)
 
 
 def _upsert_user(google_sub: str, email: str, display_name: str | None, picture_url: str | None) -> int:

--- a/app/config.py
+++ b/app/config.py
@@ -18,6 +18,7 @@ class Settings:
     db_path: Path
     content_dir: Path
     cookie_secure: bool
+    blog_url: str
 
 
 def _require(name: str) -> str:
@@ -47,6 +48,7 @@ def load_settings() -> Settings:
         db_path=Path(os.getenv("DB_PATH", str(APP_DIR / "paperpulse.sqlite"))),
         content_dir=Path(os.getenv("CONTENT_DIR", str(REPO_ROOT / "content"))),
         cookie_secure=os.getenv("COOKIE_SECURE", "false").lower() == "true",
+        blog_url=os.getenv("BLOG_URL", "https://paperpulse.ukurup.com").rstrip("/"),
     )
 
 

--- a/app/routes.py
+++ b/app/routes.py
@@ -37,6 +37,13 @@ async def index(request: Request, user: dict | None = Depends(current_user)):
     )
 
 
+@router.get("/login", response_class=HTMLResponse)
+async def login_page(request: Request, user: dict | None = Depends(current_user)):
+    if user:
+        return RedirectResponse(url="/feed", status_code=HTTP_302_FOUND)
+    return templates.TemplateResponse(request, "login.html", {"user": None})
+
+
 @router.get("/healthz")
 async def healthz():
     try:
@@ -133,12 +140,11 @@ async def delete_account(request: Request, user: dict | None = Depends(current_u
     if not _validate_csrf(request, submitted_token):
         return PlainTextResponse("Invalid CSRF token", status_code=403)
     with get_conn() as conn:
-        conn.execute(
-            "UPDATE users SET deleted_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP WHERE id = ?",
-            (user["id"],),
-        )
+        # Hard delete: removes the user row and, via ON DELETE CASCADE, all
+        # category selections. Nothing about the account is retained.
+        conn.execute("DELETE FROM users WHERE id = ?", (user["id"],))
     request.session.clear()
-    return RedirectResponse(url="/", status_code=HTTP_302_FOUND)
+    return RedirectResponse(url=f"{settings.blog_url}/?account_deleted=1", status_code=HTTP_302_FOUND)
 
 
 @router.get("/feed", response_class=HTMLResponse)

--- a/app/routes.py
+++ b/app/routes.py
@@ -139,6 +139,9 @@ async def delete_account(request: Request, user: dict | None = Depends(current_u
     submitted_token = next((v for k, v in fields if k == "csrf_token"), None)
     if not _validate_csrf(request, submitted_token):
         return PlainTextResponse("Invalid CSRF token", status_code=403)
+    confirmed = next((v for k, v in fields if k == "confirm"), None)
+    if confirmed != "yes":
+        return PlainTextResponse("Deletion not confirmed", status_code=400)
     with get_conn() as conn:
         # Hard delete: removes the user row and, via ON DELETE CASCADE, all
         # category selections. Nothing about the account is retained.

--- a/app/static/app.css
+++ b/app/static/app.css
@@ -97,6 +97,27 @@ button[type="submit"].button-danger:hover {
   background: #7f0017;
 }
 
+/* Login page */
+.button-link {
+  display: inline-block;
+  padding: 8px 16px;
+  border: 1px solid #2a7ae2;
+  border-radius: 3px;
+  background: #2a7ae2;
+  color: #fff !important;
+  text-decoration: none;
+}
+
+.button-link:hover {
+  background: #1756a9;
+  text-decoration: none;
+}
+
+.login-note {
+  color: #828282;
+  font-size: 14px;
+}
+
 /* Feed */
 .feed-category {
   margin-bottom: 30px;

--- a/app/static/app.css
+++ b/app/static/app.css
@@ -5,6 +5,47 @@
   margin-right: 10px;
 }
 
+/* Left sidebar for links common to the blog and the app (mirrored in
+   blog/assets/custom.css); contextual links stay in the top-right nav. */
+.layout-wrap {
+  display: flex;
+  align-items: flex-start;
+}
+
+.site-sidebar {
+  width: 200px;
+  flex-shrink: 0;
+  padding: 30px 0 30px 30px;
+}
+
+.site-sidebar .page-link {
+  display: block;
+  margin-bottom: 10px;
+  color: #111;
+}
+
+.layout-wrap .page-content {
+  flex: 1;
+  min-width: 0;
+}
+
+@media screen and (max-width: 600px) {
+  .layout-wrap {
+    display: block;
+  }
+
+  .site-sidebar {
+    width: auto;
+    padding: 15px 15px 0;
+  }
+
+  .site-sidebar .page-link {
+    display: inline-block;
+    margin-right: 15px;
+    margin-bottom: 0;
+  }
+}
+
 /* Category picker */
 #category-search {
   width: 100%;

--- a/app/static/app.css
+++ b/app/static/app.css
@@ -93,6 +93,17 @@ button[type="submit"].button-danger {
   background: #b00020;
 }
 
+button[type="submit"].button-danger:disabled {
+  border-color: #d9a3ae;
+  background: #d9a3ae;
+  cursor: not-allowed;
+}
+
+.delete-confirm {
+  display: block;
+  margin-bottom: 10px;
+}
+
 button[type="submit"].button-danger:hover {
   background: #7f0017;
 }

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -30,14 +30,23 @@
           {% else %}
             <a class="page-link" href="/auth/login">Sign in with Google</a>
           {% endif %}
-          <a class="page-link" href="https://paperpulse.ukurup.com">Blog</a>
         </div>
       </nav>
     </div>
   </header>
-  <main class="page-content" aria-label="Content">
-    <div class="wrapper">{% block content %}{% endblock %}</div>
-  </main>
+  <div class="layout-wrap">
+    <aside class="site-sidebar" aria-label="Site">
+      <nav>
+        <a class="page-link" href="https://paperpulse.ukurup.com/about/">About</a>
+        <a class="page-link" href="https://paperpulse.ukurup.com/whatsnew/">What's New</a>
+        <a class="page-link" href="https://coff.ee/unmeshk" target="_blank">Buy me a coffee</a>
+      </nav>
+    </aside>
+
+    <main class="page-content" aria-label="Content">
+      <div class="wrapper">{% block content %}{% endblock %}</div>
+    </main>
+  </div>
   <footer class="site-footer h-card">
     <div class="wrapper">
       <div class="footer-col-wrapper">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -28,7 +28,7 @@
             <a class="page-link" href="/settings">Settings</a>
             <a class="page-link" href="/auth/logout">Sign out</a>
           {% else %}
-            <a class="page-link" href="/auth/login">Sign in with Google</a>
+            <a class="page-link" href="/login">Log in</a>
           {% endif %}
         </div>
       </nav>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -9,6 +9,6 @@
     <p>Next: category picker (not built yet).</p>
   {% else %}
     <h1>PaperPulse</h1>
-    <p>Personalized arXiv summaries. Sign in with Google to get started.</p>
+    <p>Personalized arXiv summaries. <a href="/login">Sign in</a> to get started.</p>
   {% endif %}
 {% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block title %}Sign in — PaperPulse{% endblock %}
+{% block content %}
+  <h1>Sign in to PaperPulse</h1>
+  <p>Get a daily, personalized summary of new arXiv papers in the categories you choose.</p>
+
+  <p><a class="button-link" href="/auth/login">Continue with Google</a></p>
+
+  <p class="login-note">
+    Signing in for the first time creates your account. We store your email and
+    name for login and personalization only.
+  </p>
+{% endblock %}

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -27,7 +27,7 @@
   <hr>
 
   <h2>Delete account</h2>
-  <p>This soft-deletes your account and signs you out.</p>
+  <p>Permanently deletes your account and all its data (including your category selections), and signs you out. This cannot be undone.</p>
   <form method="post" action="/settings/delete-account">
     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
     <button type="submit" class="button-danger">Delete my account</button>

--- a/app/templates/settings.html
+++ b/app/templates/settings.html
@@ -30,8 +30,21 @@
   <p>Permanently deletes your account and all its data (including your category selections), and signs you out. This cannot be undone.</p>
   <form method="post" action="/settings/delete-account">
     <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
-    <button type="submit" class="button-danger">Delete my account</button>
+    <label class="delete-confirm">
+      <input type="checkbox" id="delete-confirm-box" name="confirm" value="yes">
+      I understand this permanently deletes my account and all its data.
+    </label>
+    <button type="submit" id="delete-account-button" class="button-danger" disabled>Delete my account</button>
   </form>
+  <script>
+    (function () {
+      var box = document.getElementById("delete-confirm-box");
+      var button = document.getElementById("delete-account-button");
+      box.addEventListener("change", function () {
+        button.disabled = !box.checked;
+      });
+    })();
+  </script>
 
   <script>
     (function () {

--- a/app/tests/test_feed.py
+++ b/app/tests/test_feed.py
@@ -110,4 +110,4 @@ def test_index_logged_in_without_categories_redirects_to_onboarding(auth_client)
 def test_index_anonymous_renders_landing(client):
     resp = client.get("/")
     assert resp.status_code == 200
-    assert "Sign in with Google" in resp.text
+    assert 'href="/login"' in resp.text

--- a/app/tests/test_settings.py
+++ b/app/tests/test_settings.py
@@ -106,7 +106,7 @@ def test_delete_account_hard_deletes_all_data(auth_client, db_user):
     token = _csrf(auth_client, "/settings")
     resp = auth_client.post(
         "/settings/delete-account",
-        data={"csrf_token": token},
+        data={"csrf_token": token, "confirm": "yes"},
         follow_redirects=False,
     )
     assert resp.status_code == 302
@@ -132,6 +132,21 @@ def test_delete_account_missing_csrf_forbidden(auth_client):
     assert resp.status_code == 403
 
 
+def test_delete_account_requires_confirmation(auth_client, db_user):
+    from app.db import get_conn
+
+    token = _csrf(auth_client, "/settings")
+    resp = auth_client.post(
+        "/settings/delete-account",
+        data={"csrf_token": token},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 400
+    with get_conn() as conn:
+        row = conn.execute("SELECT id FROM users WHERE id = ?", (db_user["id"],)).fetchone()
+    assert row is not None  # unconfirmed request deletes nothing
+
+
 def test_after_delete_index_is_anonymous(auth_client, db_user):
     from app.auth import current_user
     from app.main import app
@@ -139,7 +154,7 @@ def test_after_delete_index_is_anonymous(auth_client, db_user):
     token = _csrf(auth_client, "/settings")
     auth_client.post(
         "/settings/delete-account",
-        data={"csrf_token": token},
+        data={"csrf_token": token, "confirm": "yes"},
         follow_redirects=False,
     )
     # Drop the override so current_user uses the real (now-cleared) session.

--- a/app/tests/test_settings.py
+++ b/app/tests/test_settings.py
@@ -99,7 +99,8 @@ def test_settings_post_anonymous_blocked(client):
 # --- delete account ------------------------------------------------------------
 
 
-def test_delete_account_soft_deletes(auth_client, db_user):
+def test_delete_account_hard_deletes_all_data(auth_client, db_user):
+    from app.config import settings
     from app.db import get_conn
 
     token = _csrf(auth_client, "/settings")
@@ -109,13 +110,16 @@ def test_delete_account_soft_deletes(auth_client, db_user):
         follow_redirects=False,
     )
     assert resp.status_code == 302
-    assert resp.headers["location"] == "/"
+    assert resp.headers["location"] == f"{settings.blog_url}/?account_deleted=1"
     with get_conn() as conn:
-        row = conn.execute(
-            "SELECT deleted_at FROM users WHERE id = ?", (db_user["id"],)
+        user_row = conn.execute(
+            "SELECT id FROM users WHERE id = ?", (db_user["id"],)
         ).fetchone()
-    assert row is not None  # row still exists (soft delete)
-    assert row["deleted_at"] is not None  # deleted_at set
+        cat_rows = conn.execute(
+            "SELECT * FROM user_categories WHERE user_id = ?", (db_user["id"],)
+        ).fetchall()
+    assert user_row is None  # user row gone
+    assert cat_rows == []  # category selections cascade-deleted
 
 
 def test_delete_account_missing_csrf_forbidden(auth_client):
@@ -142,4 +146,4 @@ def test_after_delete_index_is_anonymous(auth_client, db_user):
     app.dependency_overrides.pop(current_user, None)
     resp = auth_client.get("/")
     assert resp.status_code == 200
-    assert "Sign in with Google" in resp.text
+    assert 'href="/login"' in resp.text

--- a/app/tests/test_smoke.py
+++ b/app/tests/test_smoke.py
@@ -8,3 +8,12 @@ def test_index_renders_for_anonymous(client):
     response = client.get("/")
     assert response.status_code == 200
     assert "Sign in with Google" in response.text
+
+
+def test_logout_redirects_to_blog_with_banner_param(client):
+    response = client.get("/auth/logout", follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"].endswith("/?logged_out=1")
+    from app.config import settings
+
+    assert response.headers["location"] == f"{settings.blog_url}/?logged_out=1"

--- a/app/tests/test_smoke.py
+++ b/app/tests/test_smoke.py
@@ -7,7 +7,14 @@ def test_healthz_returns_ok(client):
 def test_index_renders_for_anonymous(client):
     response = client.get("/")
     assert response.status_code == 200
-    assert "Sign in with Google" in response.text
+    assert 'href="/login"' in response.text
+
+
+def test_login_page_renders_for_anonymous(client):
+    response = client.get("/login")
+    assert response.status_code == 200
+    assert "Continue with Google" in response.text
+    assert 'href="/auth/login"' in response.text
 
 
 def test_logout_redirects_to_blog_with_banner_param(client):

--- a/blog/_includes/head.html
+++ b/blog/_includes/head.html
@@ -4,6 +4,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   {%- seo -%}
   <link rel="stylesheet" href="{{ "/assets/main.css" | relative_url }}">
+  <link rel="stylesheet" href="{{ "/assets/custom.css" | relative_url }}">
   {%- feed_meta -%}
   
   {% if jekyll.environment == "production" %}

--- a/blog/_includes/header.html
+++ b/blog/_includes/header.html
@@ -1,7 +1,7 @@
 <header class="site-header" role="banner">
     <div class="wrapper">
       <a class="site-title" rel="author" href="{{ "/" | relative_url }}">{{ site.title | escape }}</a>
-  
+
       <nav class="site-nav">
         <input type="checkbox" id="nav-trigger" class="nav-trigger" />
         <label for="nav-trigger">
@@ -13,9 +13,6 @@
         </label>
        
         <div class="trigger">
-          <a class="page-link" href="{{ '/about/' | relative_url }}">About</a>
-          <a class="page-link" href="{{ '/whatsnew/' | relative_url }}">What's New</a>
-          <a class="page-link" href="https://coff.ee/unmeshk" target="_blank">Buy me a coffee</a>
           <a class="page-link" href="https://app.paperpulse.ukurup.com/">Log in</a>
         </div>
       </nav>

--- a/blog/_includes/header.html
+++ b/blog/_includes/header.html
@@ -13,7 +13,7 @@
         </label>
        
         <div class="trigger">
-          <a class="page-link" href="https://app.paperpulse.ukurup.com/">Log in</a>
+          <a class="page-link" href="https://app.paperpulse.ukurup.com/login">Log in</a>
         </div>
       </nav>
     </div>

--- a/blog/_layouts/default.html
+++ b/blog/_layouts/default.html
@@ -7,13 +7,22 @@
 
     {%- include header.html -%}
 
-    <div id="logged-out-banner" class="logged-out-banner" hidden>You are now logged out.</div>
+    <div id="logged-out-banner" class="logged-out-banner" hidden></div>
     <script>
       (function () {
         var params = new URLSearchParams(window.location.search);
+        var message = null;
         if (params.get("logged_out") === "1") {
-          document.getElementById("logged-out-banner").hidden = false;
+          message = "You are now logged out.";
           params.delete("logged_out");
+        } else if (params.get("account_deleted") === "1") {
+          message = "Your account and all its data have been deleted.";
+          params.delete("account_deleted");
+        }
+        if (message) {
+          var banner = document.getElementById("logged-out-banner");
+          banner.textContent = message;
+          banner.hidden = false;
           var qs = params.toString();
           history.replaceState(null, "", window.location.pathname + (qs ? "?" + qs : ""));
         }

--- a/blog/_layouts/default.html
+++ b/blog/_layouts/default.html
@@ -7,11 +7,34 @@
 
     {%- include header.html -%}
 
-    <main class="page-content" aria-label="Content">
-      <div class="wrapper">
-        {{ content }}
-      </div>
-    </main>
+    <div id="logged-out-banner" class="logged-out-banner" hidden>You are now logged out.</div>
+    <script>
+      (function () {
+        var params = new URLSearchParams(window.location.search);
+        if (params.get("logged_out") === "1") {
+          document.getElementById("logged-out-banner").hidden = false;
+          params.delete("logged_out");
+          var qs = params.toString();
+          history.replaceState(null, "", window.location.pathname + (qs ? "?" + qs : ""));
+        }
+      })();
+    </script>
+
+    <div class="layout-wrap">
+      <aside class="site-sidebar" aria-label="Site">
+        <nav>
+          <a class="page-link" href="{{ '/about/' | relative_url }}">About</a>
+          <a class="page-link" href="{{ '/whatsnew/' | relative_url }}">What's New</a>
+          <a class="page-link" href="https://coff.ee/unmeshk" target="_blank">Buy me a coffee</a>
+        </nav>
+      </aside>
+
+      <main class="page-content" aria-label="Content">
+        <div class="wrapper">
+          {{ content }}
+        </div>
+      </main>
+    </div>
 
     {%- include footer.html -%}
 

--- a/blog/assets/custom.css
+++ b/blog/assets/custom.css
@@ -1,0 +1,49 @@
+/* Left sidebar for links common to the blog and the app; contextual links
+   stay in the top-right header nav. Mirrored in app/static/app.css. */
+
+.logged-out-banner {
+  background: #eef6ee;
+  border-bottom: 1px solid #cde3cd;
+  color: #2b6a2b;
+  padding: 8px 15px;
+  text-align: center;
+}
+
+.layout-wrap {
+  display: flex;
+  align-items: flex-start;
+}
+
+.site-sidebar {
+  width: 200px;
+  flex-shrink: 0;
+  padding: 30px 0 30px 30px;
+}
+
+.site-sidebar .page-link {
+  display: block;
+  margin-bottom: 10px;
+  color: #111;
+}
+
+.layout-wrap .page-content {
+  flex: 1;
+  min-width: 0;
+}
+
+@media screen and (max-width: 600px) {
+  .layout-wrap {
+    display: block;
+  }
+
+  .site-sidebar {
+    width: auto;
+    padding: 15px 15px 0;
+  }
+
+  .site-sidebar .page-link {
+    display: inline-block;
+    margin-right: 15px;
+    margin-bottom: 0;
+  }
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -10,6 +10,7 @@ Core app + pipeline shipped and verified in prod (2026-07-18). Remaining before 
 3. **Dedicated login/signup page.** Interstitial between "login" click and the Google OAuth redirect, instead of the bare landing-page link.
 4. **Logout lands on the main blog page** with a "you are now logged out" message. Note: blog is static Jekyll, so the message needs a query-param + small JS include (or a static logged-out page variant).
 5. **Hard delete.** Account deletion removes all user data — user row + category selections. Schema already has `ON DELETE CASCADE`, so either hard-delete on request or a purge job replacing the current soft-delete-only flow.
+6. **"Buy me a coffee" on the personalized feed.** Find a placement for the coffee link in the app (blog already has it in the header nav).
 
 ## Phase 2 — Next major release (post-Phase 1)
 Feedback-driven feed improvement. Readers mark sections / papers / themes as "more like this" or "less like this." The system uses the signal to re-rank or re-prompt summaries over time. End state: each user's feed continually adapts to their preferences.


### PR DESCRIPTION
Ships the remaining Phase 1 items in one batch:

- **Shared left sidebar** (blog + app): About / What's New / Buy me a coffee move to a left sidebar; top-right nav keeps contextual links (blog: Log in; app: email, Feed, Settings, Sign out). Collapses to a horizontal row on mobile. Covers roadmap item 6 (coffee link in app).
- **/login interstitial** (item 3): dedicated sign-in page with Continue with Google; blog header, app nav, and landing route through it.
- **Logout lands on the blog** (item 4) with a "You are now logged out." banner via ?logged_out=1; BLOG_URL setting defaults to prod.
- **Hard delete** (item 5): delete-account removes the user row + category selections (cascade), lands on the blog with an "account deleted" banner. Confirmation checkbox required, enforced server-side (400 without it).

Also carries the two roadmap docs commits. 42/42 app tests pass; all flows verified E2E locally (blog on :4000 via digest-pinned jekyll image, app on :8000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)