### PR TITLE
Fix Mixpanel: real project token, drop broken !ENV wiring

### DIFF
--- a/blog/_config.yml
+++ b/blog/_config.yml
@@ -24,8 +24,11 @@ description: >- # this means to ignore newlines until "baseurl:"
   Your daily summary of ML papers on ArXiV
 baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
-# Analytics
-mixpanel_token: !ENV MIXPANEL_TOKEN
+# Analytics. The Mixpanel project token is a public client-side identifier
+# (it ships in the served JS on every page), so it lives directly in config.
+# NOTE: plain Jekyll has no !ENV support — a previous attempt to read this
+# from the environment produced the literal string "MIXPANEL_TOKEN".
+mixpanel_token: 6e1c3105902b102d105256b6dd8d421b
 
 
 # Build settings

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,7 +7,6 @@ services:
       - ./blog:/srv/jekyll
     environment:
       - JEKYLL_ENV=production
-      - MIXPANEL_TOKEN=${MIXPANEL_TOKEN}
     networks:
       - web
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - ./blog:/srv/jekyll
     environment:
       - JEKYLL_ENV=development
-      - MIXPANEL_TOKEN=${MIXPANEL_TOKEN}
     command: jekyll serve --livereload
 
 


### PR DESCRIPTION
Mixpanel never received events: vanilla Jekyll doesn't support the `!ENV` YAML tag, so prod pages ran `mixpanel.init("MIXPANEL_TOKEN")` — the literal string. On top of that, `MIXPANEL_TOKEN` was never set on the droplet (source of the compose warning on every invocation).

- `_config.yml`: real project token inline (public client-side identifier by design)
- Both compose files: dead `MIXPANEL_TOKEN` env lines removed

Verified locally: production build renders `mixpanel.init("6e1c…421b")` with event-tracking present. Prod ingestion check after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)