### PR TITLE
Privacy policy page at /privacy/

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -52,6 +52,7 @@
       <div class="footer-col-wrapper">
         <div class="footer-col footer-col-1">
           <p>Your daily summary of ML papers on ArXiV</p>
+          <p><a href="https://paperpulse.ukurup.com/privacy/">Privacy Policy</a></p>
         </div>
       </div>
     </div>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -8,6 +8,7 @@
 
   <p class="login-note">
     Signing in for the first time creates your account. We store your email and
-    name for login and personalization only.
+    name for login and personalization only — see the
+    <a href="https://paperpulse.ukurup.com/privacy/">privacy policy</a>.
   </p>
 {% endblock %}

--- a/blog/_includes/footer.html
+++ b/blog/_includes/footer.html
@@ -5,6 +5,7 @@
     <div class="footer-col-wrapper">
       <div class="footer-col footer-col-1">
         <p>{{ site.description | escape }}</p>
+        <p><a href="{{ '/privacy/' | relative_url }}">Privacy Policy</a></p>
       </div>
     </div>
   </div>

--- a/blog/privacy.markdown
+++ b/blog/privacy.markdown
@@ -34,8 +34,11 @@ Three third parties are involved in running the site: Google (sign-in), Mixpanel
 
 ### How long we keep it
 
-Until you delete your account. Deleting your account (Settings → Delete account) permanently removes your account and all its data — immediately, with no retention period.
+Until you delete your account. Deleting your account (Settings → Delete account) immediately and permanently removes your account and all its data from our systems.
+
+One exception: we take a daily backup snapshot of the server, and snapshots are kept for 7 days. A deleted account may persist inside those snapshots until they expire, after which it is gone entirely. Backups are used only for disaster recovery — we never restore them to recover a deleted account.
 
 ### Contact
 
-Questions about this policy: reach me via [ukurup.com](https://ukurup.com).
+Questions about this policy or your data: [privacy@ukurup.com](mailto:privacy@ukurup.com)
+

--- a/blog/privacy.markdown
+++ b/blog/privacy.markdown
@@ -1,0 +1,41 @@
+---
+layout: page
+title: Privacy Policy
+permalink: /privacy/
+---
+
+*Last updated: July 19, 2026*
+
+PaperPulse is a daily arXiv summary site with an optional personalized feed. This page describes what data we collect and what we do with it.
+
+### What we collect
+
+**If you just read the blog:** we collect basic usage analytics via Mixpanel (pages viewed, links clicked, time on page). No account, no personal information.
+
+**If you sign in to the personalized feed:** we receive your email address, name, profile picture, and account identifier from Google when you sign in. We also store the arXiv categories you select.
+
+**Cookies:** a session cookie to keep you signed in, and a small indicator cookie so the site header can show whether you're signed in. Neither is used for tracking.
+
+### What we use it for
+
+- Signing you in and keeping your session active
+- Showing you the daily summaries for the categories you picked
+- Understanding how the site is used (analytics)
+
+That's all. We don't sell your data, share it with advertisers, or use it for anything beyond running PaperPulse.
+
+### Where it lives
+
+Data is stored on a server hosted by DigitalOcean in New York, USA.
+
+### Service providers
+
+Three third parties are involved in running the site: Google (sign-in), Mixpanel (blog analytics), and DigitalOcean (hosting). Each receives only what's needed for its function.
+
+### How long we keep it
+
+Until you delete your account. Deleting your account (Settings → Delete account) permanently removes your account and all its data — immediately, with no retention period.
+
+### Contact
+
+Questions about this policy: reach me via [ukurup.com](https://ukurup.com).


### PR DESCRIPTION
One-pager required for the Google OAuth consent screen before leaving Testing mode.

Covers: data collected (Google profile basics, category selections, cookies, blog-only Mixpanel analytics), purpose, storage (DigitalOcean NYC), providers, retention (immediate hard delete + 7-day backup snapshot window, no restore of deleted accounts), contact (privacy@ukurup.com).

Linked from the blog footer, the app footer, and the /login note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)