### PR TITLE
Personalized feed archive: date list + per-day pages

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -1,3 +1,4 @@
+import re
 import secrets
 from datetime import datetime
 from itertools import groupby
@@ -152,19 +153,66 @@ async def delete_account(request: Request, user: dict | None = Depends(current_u
     return response
 
 
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+
+def _available_dates(slugs) -> list[str]:
+    """Dates (newest first) with a blurb file for at least one of the categories."""
+    root = settings.content_dir
+    if not root.is_dir():
+        return []
+    dates = [
+        child.name
+        for child in root.iterdir()
+        if child.is_dir()
+        and _DATE_RE.match(child.name)
+        and any((child / f"{slug}.md").is_file() for slug in slugs)
+    ]
+    return sorted(dates, reverse=True)
+
+
 @router.get("/feed", response_class=HTMLResponse)
-async def feed(request: Request, user: dict | None = Depends(current_user)):
+async def feed_index(request: Request, user: dict | None = Depends(current_user)):
     if not user:
         return RedirectResponse(url="/auth/login", status_code=HTTP_302_FOUND)
     slugs = _user_category_slugs(user["id"])  # alphabetical by slug
     if not slugs:
         return RedirectResponse(url="/onboarding", status_code=HTTP_302_FOUND)
 
-    today = datetime.now(FEED_TZ).strftime("%Y-%m-%d")
-    day_dir = settings.content_dir / today
-    day_dir_exists = day_dir.is_dir()
-    names = _display_names(slugs)
+    # Group the available dates into month buckets, blog-homepage style.
+    months = []
+    for day in _available_dates(slugs):
+        dt = datetime.strptime(day, "%Y-%m-%d")
+        month_label = dt.strftime("%B %Y")
+        entry = {"date": day, "label": dt.strftime("%b %d, %a")}
+        if months and months[-1]["label"] == month_label:
+            months[-1]["entries"].append(entry)
+        else:
+            months.append({"label": month_label, "entries": [entry]})
 
+    return templates.TemplateResponse(
+        request,
+        "feed_index.html",
+        {"user": user, "months": months},
+    )
+
+
+@router.get("/feed/{day}", response_class=HTMLResponse)
+async def feed_day(day: str, request: Request, user: dict | None = Depends(current_user)):
+    if not user:
+        return RedirectResponse(url="/auth/login", status_code=HTTP_302_FOUND)
+    slugs = _user_category_slugs(user["id"])  # alphabetical by slug
+    if not slugs:
+        return RedirectResponse(url="/onboarding", status_code=HTTP_302_FOUND)
+
+    # Only dates that actually have content for this user are linkable; anything
+    # else (bad format, missing day, other users' categories only) goes back to
+    # the date list rather than rendering an empty page.
+    day_dir = settings.content_dir / day
+    if not _DATE_RE.match(day) or not any((day_dir / f"{slug}.md").is_file() for slug in slugs):
+        return RedirectResponse(url="/feed", status_code=HTTP_302_FOUND)
+
+    names = _display_names(slugs)
     sections = []
     for slug in slugs:
         path = day_dir / f"{slug}.md"
@@ -174,7 +222,7 @@ async def feed(request: Request, user: dict | None = Depends(current_user)):
     return templates.TemplateResponse(
         request,
         "feed.html",
-        {"user": user, "today": today, "day_dir_exists": day_dir_exists, "sections": sections},
+        {"user": user, "day": day, "sections": sections},
     )
 
 

--- a/app/static/app.css
+++ b/app/static/app.css
@@ -129,6 +129,16 @@ button[type="submit"].button-danger:hover {
   font-size: 14px;
 }
 
+/* Feed date list */
+.feed-dates {
+  list-style: none;
+  margin-left: 0;
+}
+
+.feed-dates li {
+  padding: 2px 0;
+}
+
 /* Feed */
 .feed-category {
   margin-bottom: 30px;

--- a/app/templates/feed.html
+++ b/app/templates/feed.html
@@ -1,19 +1,16 @@
 {% extends "base.html" %}
-{% block title %}Your feed — PaperPulse{% endblock %}
+{% block title %}Your feed — {{ day }} — PaperPulse{% endblock %}
 {% block content %}
-  <h1>Your feed — {{ today }}</h1>
-  {% if not day_dir_exists %}
-    <p>No summaries yet. The daily pipeline runs at 6am Eastern — check back later.</p>
-  {% else %}
-    {% for s in sections %}
-      <section class="feed-category" data-slug="{{ s.slug }}">
-        <h2>{{ s.slug }} — {{ s.display_name }}</h2>
-        {% if s.html %}
-          {{ s.html | safe }}
-        {% else %}
-          <p>No new papers today.</p>
-        {% endif %}
-      </section>
-    {% endfor %}
-  {% endif %}
+  <p><a href="/feed">&larr; All days</a></p>
+  <h1>Your feed — {{ day }}</h1>
+  {% for s in sections %}
+    <section class="feed-category" data-slug="{{ s.slug }}">
+      <h2>{{ s.slug }} — {{ s.display_name }}</h2>
+      {% if s.html %}
+        {{ s.html | safe }}
+      {% else %}
+        <p>No new papers today.</p>
+      {% endif %}
+    </section>
+  {% endfor %}
 {% endblock %}

--- a/app/templates/feed_index.html
+++ b/app/templates/feed_index.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Your feed — PaperPulse{% endblock %}
+{% block content %}
+  <h1>Your feed</h1>
+  {% if not months %}
+    <p>No summaries yet — your first personalized summaries appear after the next daily run (6am Eastern).</p>
+  {% else %}
+    {% for month in months %}
+      <h2>{{ month.label }}</h2>
+      <ul class="feed-dates">
+        {% for e in month.entries %}
+          <li><a href="/feed/{{ e.date }}">{{ e.label }}</a></li>
+        {% endfor %}
+      </ul>
+    {% endfor %}
+  {% endif %}
+{% endblock %}

--- a/app/tests/test_feed.py
+++ b/app/tests/test_feed.py
@@ -1,6 +1,6 @@
-"""Tests for chunk 2 — feed page.
+"""Tests for the feed: date-list archive (/feed) and per-day pages (/feed/<date>).
 
-Covers every acceptance criterion in docs/PHASE1_CHUNKS.md chunk 2.
+Originally covered docs/PHASE1_CHUNKS.md chunk 2; extended for the archive.
 """
 from app.tests.conftest import feed_today
 
@@ -10,6 +10,12 @@ from app.tests.conftest import feed_today
 
 def test_feed_anonymous_redirects_to_login(client):
     resp = client.get("/feed", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/auth/login"
+
+
+def test_feed_day_anonymous_redirects_to_login(client):
+    resp = client.get(f"/feed/{feed_today()}", follow_redirects=False)
     assert resp.status_code == 302
     assert resp.headers["location"] == "/auth/login"
 
@@ -26,69 +32,112 @@ def test_feed_with_categories_returns_200(auth_client, assign_categories):
     assert resp.status_code == 200
 
 
-# --- rendering -----------------------------------------------------------------
+# --- date list -----------------------------------------------------------------
 
 
-def test_feed_sections_alphabetical_by_slug(auth_client, assign_categories, write_blurb):
+def test_feed_lists_dates_with_user_content_newest_first(auth_client, assign_categories, write_blurb):
+    assign_categories(["cs.LG"])
+    write_blurb("cs.LG", "old", date="2026-07-01")
+    write_blurb("cs.LG", "new", date="2026-07-15")
+    html = auth_client.get("/feed").text
+    assert 'href="/feed/2026-07-15"' in html
+    assert 'href="/feed/2026-07-01"' in html
+    assert html.index("2026-07-15") < html.index("2026-07-01")
+
+
+def test_feed_list_excludes_dates_without_user_categories(auth_client, assign_categories, write_blurb):
+    assign_categories(["cs.LG"])
+    write_blurb("cs.AI", "not my category", date="2026-07-10")  # other users' category only
+    html = auth_client.get("/feed").text
+    assert "2026-07-10" not in html
+
+
+def test_feed_list_groups_by_month(auth_client, assign_categories, write_blurb):
+    assign_categories(["cs.LG"])
+    write_blurb("cs.LG", "june", date="2026-06-30")
+    write_blurb("cs.LG", "july", date="2026-07-01")
+    html = auth_client.get("/feed").text
+    assert "July 2026" in html
+    assert "June 2026" in html
+
+
+def test_feed_list_empty_shows_first_run_message(auth_client, assign_categories):
+    assign_categories(["cs.LG"])
+    resp = auth_client.get("/feed")
+    assert resp.status_code == 200
+    assert "after the next daily run" in resp.text
+
+
+# --- per-day page --------------------------------------------------------------
+
+
+def test_feed_day_sections_alphabetical_by_slug(auth_client, assign_categories, write_blurb):
     assign_categories(["stat.ML", "cs.AI", "cs.LG"])
     for slug in ["stat.ML", "cs.AI", "cs.LG"]:
         write_blurb(slug, f"Body for {slug}.")
-    html = auth_client.get("/feed").text
+    html = auth_client.get(f"/feed/{feed_today()}").text
     pos = [html.index(f'data-slug="{s}"') for s in ["cs.AI", "cs.LG", "stat.ML"]]
     assert pos == sorted(pos)
 
 
-def test_feed_section_heading_shows_category(auth_client, assign_categories, write_blurb):
+def test_feed_day_heading_shows_category(auth_client, assign_categories, write_blurb):
     assign_categories(["cs.LG"])
     write_blurb("cs.LG", "Body.")
-    html = auth_client.get("/feed").text
+    html = auth_client.get(f"/feed/{feed_today()}").text
     assert "cs.LG" in html
     # display_name from seeded categories
     assert "Machine Learning" in html
 
 
-def test_feed_renders_markdown_to_html(auth_client, assign_categories, write_blurb):
+def test_feed_day_renders_markdown_to_html(auth_client, assign_categories, write_blurb):
     assign_categories(["cs.LG"])
     write_blurb("cs.LG", "## Theme 1: Scaling laws\n\n[Big Paper](http://arxiv.org/abs/2401.1)")
-    html = auth_client.get("/feed").text
+    html = auth_client.get(f"/feed/{feed_today()}").text
     assert "Theme 1: Scaling laws</h2>" in html
     assert 'href="http://arxiv.org/abs/2401.1"' in html
     assert ">Big Paper</a>" in html
 
 
-def test_feed_escapes_raw_html(auth_client, assign_categories, write_blurb):
+def test_feed_day_escapes_raw_html(auth_client, assign_categories, write_blurb):
     assign_categories(["cs.LG"])
     write_blurb("cs.LG", "Hello <script>alert(1)</script> world")
-    html = auth_client.get("/feed").text
+    html = auth_client.get(f"/feed/{feed_today()}").text
     assert "<script>alert(1)</script>" not in html
     assert "&lt;script&gt;" in html
 
 
-# --- missing content -----------------------------------------------------------
-
-
-def test_feed_missing_single_file_shows_placeholder(auth_client, assign_categories, write_blurb):
+def test_feed_day_missing_single_file_shows_placeholder(auth_client, assign_categories, write_blurb):
     assign_categories(["cs.AI", "cs.LG"])
     write_blurb("cs.LG", "Only LG has content today.")  # cs.AI file absent; day dir exists
-    resp = auth_client.get("/feed")
+    resp = auth_client.get(f"/feed/{feed_today()}")
     assert resp.status_code == 200
     assert "Only LG has content today." in resp.text
     assert "no new papers today" in resp.text.lower()
 
 
-def test_feed_missing_day_dir_shows_empty_state(auth_client, assign_categories):
-    assign_categories(["cs.LG"])  # categories selected, but no content dir for today
-    resp = auth_client.get("/feed")
-    assert resp.status_code == 200
-    assert "pipeline runs at 6am Eastern" in resp.text
+# --- unlinkable days redirect back to the list ---------------------------------
 
 
-def test_feed_uses_new_york_today(auth_client, assign_categories, write_blurb):
+def test_feed_day_without_content_redirects_to_list(auth_client, assign_categories):
+    assign_categories(["cs.LG"])  # no content written for this date
+    resp = auth_client.get("/feed/2026-01-01", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/feed"
+
+
+def test_feed_day_other_categories_only_redirects_to_list(auth_client, assign_categories, write_blurb):
     assign_categories(["cs.LG"])
-    write_blurb("cs.LG", "NY-today content.", date=feed_today())
-    resp = auth_client.get("/feed")
-    assert resp.status_code == 200
-    assert "NY-today content." in resp.text
+    write_blurb("cs.AI", "someone else's category", date="2026-07-10")
+    resp = auth_client.get("/feed/2026-07-10", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/feed"
+
+
+def test_feed_day_bad_format_redirects_to_list(auth_client, assign_categories):
+    assign_categories(["cs.LG"])
+    resp = auth_client.get("/feed/not-a-date", follow_redirects=False)
+    assert resp.status_code == 302
+    assert resp.headers["location"] == "/feed"
 
 
 # --- "/" routing ---------------------------------------------------------------

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,7 +30,7 @@ Priority order will depend on what we learn from real users; this is not a fixed
 
 1. **Free-text category input.** User types a topic of interest in plain text. System maps it to the closest cs.* category (or a curated topic vocabulary) and generates a daily summary for that custom topic, treated identically to a built-in category.
 2. **Daily email digest.** Opt-in. Sends the user's personalized feed to an email address they choose.
-3. **Personalized feed archive.** Show last N days of personalized feeds, not just today.
+3. ~~**Personalized feed archive.**~~ Shipped 2026-07-19: /feed is a month-grouped date list (only days with content for the user's categories); /feed/&lt;date&gt; renders that day.
 4. **Pricing tiers via Stripe.** E.g. free = 1 category, paid = more. Note: current LLM cost is fixed regardless of user count, so tiering is positioning/monetization, not cost recovery.
 5. **Hover-to-explain on paper titles.** Hovering a paper title in the feed pops up a short plain-language explanation of the abstract (LLM-generated, cached per paper). Reduces clicks to arXiv for skim-reading users.
 


### PR DESCRIPTION
Backlog item 3. /feed becomes the logged-in landing: a blog-style, month-grouped list of dates that have content for at least one of the user's categories, newest first. /feed/<date> renders that day's summary via the existing per-category markdown path, with a back link.

Days without content for the requesting user — missing date dir, only other users' categories, malformed date — redirect back to the list, so no "no content today" page is reachable.

50/50 app tests; verified E2E locally (list, month grouping, click-through, redirects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)